### PR TITLE
feat: Rollable and Fully Immutable Topic Ids

### DIFF
--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -4,11 +4,13 @@ title: Enable Immutable Topic Ids and Updatable Submit Keys without an Admin Key
 author: Michael Kantor (@kantorcodes)
 requested-by: Hashgraph Online
 type: Standards Track
-category: Core
-needs-council-approval: Yes
-created: 2025-03-11
+category: Service
 status: Review
+needs-hedera-approval: Yes
+needs-hiero-review: Yes
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1139
+created: 2025-03-11
+updated: 2025-07-09
 ---
 
 ## Abstract

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -5,7 +5,8 @@ author: Michael Kantor (@kantorcodes)
 requested-by: Hashgraph Online
 type: Standards Track
 category: Service
-status: Review
+status: Last Call
+last-call-date-time: 2025-07-23T07:00:00Z
 needs-hedera-approval: Yes
 needs-hiero-review: Yes
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1139

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -13,7 +13,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/11
 
 ## Abstract
 
-The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. Additionally, there's no way for a Submit Key to update itself without an admin key. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys or modifying themselves to another key, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
+The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. Additionally, there's no way for a Submit Key to update itself without an admin key. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys or modifying themselves to another key and providing a mechanism for Admin Keys to be made permanently unusable, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
 
 ## Motivation
 
@@ -21,12 +21,21 @@ Many applications require immutable topics for their use cases, yet some project
 
 1. **No Path to Immutability**: Once a topic is created with keys, there is no way to transition it to a fully immutable state. Our tests demonstrated that a submit key can ONLY be updated if an admin key is present.
 2. **No Path to Update Submit Keys**: Once a topic is created with a Submit Key Only, there is no way for it to remove or update itself. This presents security and immutability risks.
-3. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
+3. **Critical Admin Key Limitation**: The most significant limitation we discovered is that Admin Keys cannot be set to dead (unusable) keys directly, because:
+
+   - Admin Keys need to sign their own update transaction
+   - A dead key cannot provide a valid signature
+   - This creates a circular dependency that prevents making Admin Keys permanently unusable
+   - We need a special mechanism to make Admin Keys permanently unusable
+
+4. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
+
    - Setting Submit Keys to dead (unusable) keys is possible but requires Admin Key authorization
    - This is critical for making topics completely immutable by preventing any future message submissions
    - Without the ability to make Submit Keys unusable, topics remain writable even if administratively immutable
 
 5. **Inflexible Key Updates**: Our tests showed that while key updates are possible, there is no standardized mechanism to:
+   - Make Admin Keys completely unusable (they can't be set to dead keys)
    - Make Submit Keys completely unusable to prevent future message submissions
    - Transition a topic to a fully immutable state where no operations are possible
 
@@ -48,6 +57,7 @@ Based on our testing and analysis, we propose enhancing topic key management for
 
    - Converting a managed topic to a completely immutable one, for example with HCS-1.
    - Making Submit Keys unusable to prevent any future message submissions
+   - Making Admin Keys unusable to prevent any future administrative changes
 
 4. **Error Recovery**: Our testing revealed that developers who accidentally set keys during topic creation currently have no recourse except to create a new topic and migrate all messages.
 
@@ -80,6 +90,7 @@ Based on our testing and discovery of the Admin Key limitation, we propose the f
 1. **Key Immutability Mechanism**:
 
    - Submit Keys can be set to dead keys (all-zeros) to make them permanently unusable
+   - Admin Keys require a special mechanism to be made permanently unusable since they can't be set to dead keys
    - Once a key is made unusable, this operation must be permanent and irreversible
 
 2. **Implementation Flow**:
@@ -128,7 +139,7 @@ Our testing revealed several security considerations:
 1. **Key Management**:
 
    - Admin Key remains the highest privilege key until made unusable
-   - Dead keys are permanent and irreversible
+   - Dead keys and Admin Key immutability are permanent and irreversible
    - Proper key custody remains critical until intentional transition to immutability
 
 2. **Attack Vectors**:
@@ -160,7 +171,7 @@ await new TopicUpdateTransaction()
 // 3. Make Admin Key unusable for complete topic immutability
 await new TopicUpdateTransaction()
   .setTopicId(topicId)
-  .setAdminKey(KeyList.of())
+  .setAdminKey(deadKey)
   .sign(adminKey)
   .execute(client);
 ```

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -81,6 +81,8 @@ Based on our testing and real-world scenarios, we have identified the following 
 
 - As a service provider, I want to create a topic on behalf of a user with our private key as the Admin Key, and then make the Admin Key permanently unusable, ensuring no future administrative changes are possible.
 
+- As a service provider or Mirror Node, I should still be able to query all messages from a topic with dead or unstable keys (no change from current functionality)
+
 ## Specification
 
 Based on our testing and discovery of the Admin Key limitation, we propose the following changes:

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -13,7 +13,7 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/11
 
 ## Abstract
 
-The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. Additionally, there's no way for a Submit Key to update itself without an admin key. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys or modifying themselves to another key and providing a mechanism for Admin Keys to be made permanently unusable, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
+The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. Additionally, there's no way for a Submit Key to update itself without an admin key. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys or modifying themselves to another key, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
 
 ## Motivation
 
@@ -21,21 +21,12 @@ Many applications require immutable topics for their use cases, yet some project
 
 1. **No Path to Immutability**: Once a topic is created with keys, there is no way to transition it to a fully immutable state. Our tests demonstrated that a submit key can ONLY be updated if an admin key is present.
 2. **No Path to Update Submit Keys**: Once a topic is created with a Submit Key Only, there is no way for it to remove or update itself. This presents security and immutability risks.
-3. **Critical Admin Key Limitation**: The most significant limitation we discovered is that Admin Keys cannot be set to dead (unusable) keys directly, because:
-
-   - Admin Keys need to sign their own update transaction
-   - A dead key cannot provide a valid signature
-   - This creates a circular dependency that prevents making Admin Keys permanently unusable
-   - We need a special mechanism to make Admin Keys permanently unusable
-
-4. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
-
+3. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
    - Setting Submit Keys to dead (unusable) keys is possible but requires Admin Key authorization
    - This is critical for making topics completely immutable by preventing any future message submissions
    - Without the ability to make Submit Keys unusable, topics remain writable even if administratively immutable
 
 5. **Inflexible Key Updates**: Our tests showed that while key updates are possible, there is no standardized mechanism to:
-   - Make Admin Keys completely unusable (they can't be set to dead keys)
    - Make Submit Keys completely unusable to prevent future message submissions
    - Transition a topic to a fully immutable state where no operations are possible
 
@@ -57,7 +48,6 @@ Based on our testing and analysis, we propose enhancing topic key management for
 
    - Converting a managed topic to a completely immutable one, for example with HCS-1.
    - Making Submit Keys unusable to prevent any future message submissions
-   - Making Admin Keys unusable to prevent any future administrative changes
 
 4. **Error Recovery**: Our testing revealed that developers who accidentally set keys during topic creation currently have no recourse except to create a new topic and migrate all messages.
 
@@ -90,7 +80,6 @@ Based on our testing and discovery of the Admin Key limitation, we propose the f
 1. **Key Immutability Mechanism**:
 
    - Submit Keys can be set to dead keys (all-zeros) to make them permanently unusable
-   - Admin Keys require a special mechanism to be made permanently unusable since they can't be set to dead keys
    - Once a key is made unusable, this operation must be permanent and irreversible
 
 2. **Implementation Flow**:
@@ -139,7 +128,7 @@ Our testing revealed several security considerations:
 1. **Key Management**:
 
    - Admin Key remains the highest privilege key until made unusable
-   - Dead keys and Admin Key immutability are permanent and irreversible
+   - Dead keys are permanent and irreversible
    - Proper key custody remains critical until intentional transition to immutability
 
 2. **Attack Vectors**:
@@ -171,7 +160,7 @@ await new TopicUpdateTransaction()
 // 3. Make Admin Key unusable for complete topic immutability
 await new TopicUpdateTransaction()
   .setTopicId(topicId)
-  .setAdminKey(deadKey)
+  .setAdminKey(KeyList.of())
   .sign(adminKey)
   .execute(client);
 ```

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -1,6 +1,6 @@
 ---
 hip: 1139
-title: Enable Immutable Topic Ids
+title: Enable Immutable Topic Ids and Updatable Submit Keys without an Admin Key.
 author: Michael Kantor (@kantorcodes)
 requested-by: Hashgraph Online
 type: Standards Track
@@ -13,28 +13,28 @@ discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/11
 
 ## Abstract
 
-The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys and providing a mechanism for Admin Keys to be made permanently unusable, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
+The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. Additionally, there's no way for a Submit Key to update itself without an admin key. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys or modifying themselves to another key and providing a mechanism for Admin Keys to be made permanently unusable, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
 
 ## Motivation
 
 Many applications require immutable topics for their use cases, yet some project owners have unknowingly created topics with keys such as Admin Key and Submit Key set, which undermines this assumption. Through extensive testing, we have identified several key limitations in the current HCS topic key management:
 
-1. **No Path to Immutability**: Once a topic is created with keys, there is no way to transition it to a fully immutable state. Our tests demonstrated that while keys can be updated to new values, they cannot be made permanently unusable.
-
-2. **Critical Admin Key Limitation**: The most significant limitation we discovered is that Admin Keys cannot be set to dead (unusable) keys directly, because:
+1. **No Path to Immutability**: Once a topic is created with keys, there is no way to transition it to a fully immutable state. Our tests demonstrated that a submit key can ONLY be updated if an admin key is present.
+2. **No Path to Update Submit Keys**: Once a topic is created with a Submit Key Only, there is no way for it to remove or update itself. This presents security and immutability risks.
+3. **Critical Admin Key Limitation**: The most significant limitation we discovered is that Admin Keys cannot be set to dead (unusable) keys directly, because:
 
    - Admin Keys need to sign their own update transaction
    - A dead key cannot provide a valid signature
    - This creates a circular dependency that prevents making Admin Keys permanently unusable
    - We need a special mechanism to make Admin Keys permanently unusable
 
-3. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
+4. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
 
    - Setting Submit Keys to dead (unusable) keys is possible but requires Admin Key authorization
    - This is critical for making topics completely immutable by preventing any future message submissions
    - Without the ability to make Submit Keys unusable, topics remain writable even if administratively immutable
 
-4. **Inflexible Key Updates**: Our tests showed that while key updates are possible, there is no standardized mechanism to:
+5. **Inflexible Key Updates**: Our tests showed that while key updates are possible, there is no standardized mechanism to:
    - Make Admin Keys completely unusable (they can't be set to dead keys)
    - Make Submit Keys completely unusable to prevent future message submissions
    - Transition a topic to a fully immutable state where no operations are possible

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -1,0 +1,190 @@
+---
+hip: 1139
+title: Enable Immutable Topic Ids
+author: Michael Kantor (@kantorcodes)
+requested-by: Hashgraph Online
+type: Standards Track
+category: Core
+needs-council-approval: Yes
+created: 2025-03-11
+discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1139
+---
+
+## Abstract
+
+The Hedera Consensus Service (HCS) provides topics that may have opt-in administrative keys (Admin Key) and submission control keys (Submit Key). Currently, once these keys are set during topic creation, there is no mechanism to transition them to an immutable state. This proposal seeks to enable topics to be made fully immutable by setting Submit Keys to dead (unusable) keys and providing a mechanism for Admin Keys to be made permanently unusable, bringing HCS topic key management in line with capabilities in other Hedera services such as the Token Service (HIP-540).
+
+## Motivation
+
+Many applications require immutable topics for their use cases, yet some project owners have unknowingly created topics with keys such as Admin Key and Submit Key set, which undermines this assumption. Through extensive testing, we have identified several key limitations in the current HCS topic key management:
+
+1. **No Path to Immutability**: Once a topic is created with keys, there is no way to transition it to a fully immutable state. Our tests demonstrated that while keys can be updated to new values, they cannot be made permanently unusable.
+
+2. **Critical Admin Key Limitation**: The most significant limitation we discovered is that Admin Keys cannot be set to dead (unusable) keys directly, because:
+
+   - Admin Keys need to sign their own update transaction
+   - A dead key cannot provide a valid signature
+   - This creates a circular dependency that prevents making Admin Keys permanently unusable
+   - We need a special mechanism to make Admin Keys permanently unusable
+
+3. **Submit Key Limitations**: While Submit Keys can be updated by Admin Keys, we discovered in testing that:
+
+   - Setting Submit Keys to dead (unusable) keys is possible but requires Admin Key authorization
+   - This is critical for making topics completely immutable by preventing any future message submissions
+   - Without the ability to make Submit Keys unusable, topics remain writable even if administratively immutable
+
+4. **Inflexible Key Updates**: Our tests showed that while key updates are possible, there is no standardized mechanism to:
+   - Make Admin Keys completely unusable (they can't be set to dead keys)
+   - Make Submit Keys completely unusable to prevent future message submissions
+   - Transition a topic to a fully immutable state where no operations are possible
+
+These limitations force developers to either recreate topics (losing message history) or implement workarounds that may not be ideal for production environments.
+
+## Rationale
+
+Based on our testing and analysis, we propose enhancing topic key management for several reasons:
+
+1. **Alignment with HIP-540**: The Token Service already provides mechanisms for making keys permanently unusable through HIP-540. HCS should provide similar capabilities for consistency across Hedera services.
+
+2. **Development to Production Transition**: Our tests confirmed that developers need the ability to:
+
+   - Start with administrative controls for testing and setup
+   - Make Submit Keys completely unusable by setting them to dead keys
+   - Ensure no future modifications are possible once in production
+
+3. **Key Management Options**: Through our test cases, we identified common scenarios that require true immutability:
+
+   - Converting a managed topic to a completely immutable one, for example with HCS-1.
+   - Making Submit Keys unusable to prevent any future message submissions
+   - Making Admin Keys unusable to prevent any future administrative changes
+
+4. **Error Recovery**: Our testing revealed that developers who accidentally set keys during topic creation currently have no recourse except to create a new topic and migrate all messages.
+
+## Language
+
+Let's address important language to set a clear distinction between key states:
+
+- "Dead Key" refers to an all-zeros Ed25519 public key that is cryptographically impossible to sign with.
+- "Topic Immutability" refers to a state where both the Admin Key and Submit Key are unusable, ensuring no future modifications or operations are possible, but the Topic remains in Consensus Nodes (and block nodes in the future).
+- "Key Immutability" refers to making a key permanently unusable, either through setting it to a dead key (Submit Key) or through a special call.
+
+## User stories
+
+Based on our testing and real-world scenarios, we have identified the following key use cases:
+
+- As a developer, I want to make the Admin Key permanently unusable on my existing topic so that it becomes administratively immutable.
+
+- As a developer, I want to set the Submit Key to a dead key on my existing topic so that no further messages can ever be submitted.
+
+- As a developer, I want to transition my topic from a managed state to a fully immutable state by making both keys unusable.
+
+- As a service provider, I want to create a topic on behalf of a user with our private key as the Admin Key, and then make the Admin Key permanently unusable, ensuring no future administrative changes are possible.
+
+## Specification
+
+Based on our testing and discovery of the Admin Key limitation, we propose the following changes:
+
+1. **Key Immutability Mechanism**:
+
+   - Submit Keys can be set to dead keys (all-zeros) to make them permanently unusable
+   - Admin Keys require a special mechanism to be made permanently unusable since they can't be set to dead keys
+   - Once a key is made unusable, this operation must be permanent and irreversible
+
+2. **Implementation Flow**:
+
+```javascript
+// Make Submit Key unusable with a dead key
+const deadKey = PublicKey.fromBytes(new Uint8Array(32));
+await new TopicUpdateTransaction()
+  .setTopicId(topicId)
+  .setSubmitKey(deadKey)
+  .freezeWith(client)
+  .sign(adminKey);
+```
+
+3. **State Transitions**:
+
+   - A topic with both keys made unusable is fully immutable
+   - A topic with Admin Key made unusable but with an active Submit Key has immutable administration but allows signed submissions
+   - A topic with Submit Key set to a dead key but with an active Admin Key prevents message submissions but can be administratively updated
+   - Once a key is made unusable, it cannot be modified
+
+4. **HAPI Changes**:
+   The TopicUpdate transaction will be modified to:
+   - Support setting Submit Keys to dead keys (all-zeros)
+   - Ensure these operations are permanent and irreversible
+
+## Backwards Compatibility
+
+This change is fully backward compatible and opt-in:
+
+1. **Existing Topics**:
+
+   - Topics without keys remain unaffected
+   - Topics with keys continue to function as before
+   - No automatic migration is required
+
+2. **SDK Compatibility**:
+   - Existing SDK methods continue to work
+   - Key immutability functionality is additive
+   - Dead key support and Admin Key immutability mechanism are new features
+
+## Security Implications
+
+Our testing revealed several security considerations:
+
+1. **Key Management**:
+
+   - Admin Key remains the highest privilege key until made unusable
+   - Dead keys and Admin Key immutability are permanent and irreversible
+   - Proper key custody remains critical until intentional transition to immutability
+
+2. **Attack Vectors**:
+   - An attacker with Admin Key access could make keys unusable, but this would also permanently lock them out
+   - No new attack vectors are introduced
+   - Dead keys provide cryptographic guarantees of immutability
+
+## How to Teach This
+
+Based on our implementation and testing, we recommend documenting the following patterns:
+
+```javascript
+// Example: Complete immutability transition flow
+
+// 1. Create a topic with both keys for development
+const topic = await new TopicCreateTransaction()
+  .setAdminKey(adminKey)
+  .setSubmitKey(submitKey)
+  .execute(client);
+
+// 2. Make Submit Key unusable with dead key
+const deadKey = PublicKey.fromBytes(new Uint8Array(32));
+await new TopicUpdateTransaction()
+  .setTopicId(topicId)
+  .setSubmitKey(deadKey)
+  .sign(adminKey)
+  .execute(client);
+
+// 3. Make Admin Key unusable for complete topic immutability
+await new TopicUpdateTransaction()
+  .setTopicId(topicId)
+  .setAdminKey(deadKey)
+  .sign(adminKey)
+  .execute(client);
+```
+
+## Rejected Ideas
+
+1. **Empty KeyList Approach**: Using empty KeyLists was considered but rejected because it effectively makes the topic public and writable.
+2. **Deleting a topic**: Deleting a topic would make it immutable, but confusing to service providers and block nodes in the future. It should be possible to keep a topic in state while not making it writable.
+
+## References
+
+- [HIP-540: Change Or Remove Existing Keys From A Token](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-540.md)
+- [Hedera API - Consensus Service](https://docs.hedera.com/hedera/sdks-and-apis/hedera-api/consensus/consensus-service)
+- [SDK Documentation - Create a Topic](https://docs.hedera.com/hedera/sdks-and-apis/sdks/consensus-service/create-a-topic)
+- [SDK Documentation - Update a Topic](https://docs.hedera.com/hedera/sdks-and-apis/sdks/consensus-service/update-a-topic)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)

--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -7,6 +7,7 @@ type: Standards Track
 category: Core
 needs-council-approval: Yes
 created: 2025-03-11
+status: Review
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1139
 ---
 

--- a/_data/draft_hips.json
+++ b/_data/draft_hips.json
@@ -1,5 +1,25 @@
 [
   {
+    "title": "docs: replaced the discord link",
+    "number": 1135,
+    "url": "https://github.com/hashgraph/hedera-improvement-proposal/pull/1135",
+    "headRefOid": "432bf23889c59b3693587c0872a1596006700d8d",
+    "files": {
+      "edges": [
+        {
+          "node": {
+            "path": "README.md",
+            "additions": 1,
+            "deletions": 1
+          }
+        }
+      ]
+    },
+    "author": {
+      "login": "Olexandr88"
+    }
+  },
+  {
     "title": "Transaction Cleanup",
     "number": 1127,
     "url": "https://github.com/hashgraph/hedera-improvement-proposal/pull/1127",
@@ -299,7 +319,7 @@
     "title": "Updates to HIP-869",
     "number": 1089,
     "url": "https://github.com/hashgraph/hedera-improvement-proposal/pull/1089",
-    "headRefOid": "6b965083efa945e1b96a0f2da0c0611f6bf273b0",
+    "headRefOid": "908fc16a173bba566b405bc6247c9979c26fefb3",
     "files": {
       "edges": [
         {
@@ -453,16 +473,9 @@
     "title": "Update hip-1.md in preparation to Hiero migration",
     "number": 1062,
     "url": "https://github.com/hashgraph/hedera-improvement-proposal/pull/1062",
-    "headRefOid": "e01b161eff6de6251f77c101b6b7fde09a55d54c",
+    "headRefOid": "dd88208fa536f87857cd45d7bbaa24abff68fef5",
     "files": {
       "edges": [
-        {
-          "node": {
-            "path": ".github/workflows/add-hip-number.yml",
-            "additions": 0,
-            "deletions": 112
-          }
-        },
         {
           "node": {
             "path": "HIP/hip-1.md",


### PR DESCRIPTION
# HIP-1139: Enable Rollable and Immutable Topic IDs

This HIP proposes a mechanism to make Hedera Consensus Service (HCS) topics truly immutable and rollable by:

1. Allowing Submit Keys to modify themselves (like HIP-504) and to be set to dead keys (all-zeros Ed25519 public key)
2. Providing a mechanism to make Admin Keys permanently unusable

## Key Changes

- Introduces ability to make topics completely immutable through dead keys
- Aligns with HIP-540's approach to key immutability
- Maintains topic state in consensus nodes while preventing future modifications
- Provides clear transition path from managed to immutable topics

## Testing Results

The following code demonstrates it isn't possible to roll a submit key today: 

```
async function testSubmitKeyOnly(client, operatorKey) {
  // Generate keys for our demonstration
  console.log('Generating demo keys');
  const submitKey = PrivateKey.generateED25519();
  const newSubmitKey = PrivateKey.generateED25519();

  // Create a topic with ONLY a Submit Key (no Admin Key)
  console.log('\n1. Creating a topic with ONLY a Submit Key (no Admin Key)...');

  try {
    const createTx = await new TopicCreateTransaction()
      .setSubmitKey(submitKey.publicKey) // Set Submit Key only
      .setTopicMemo('Submit Key Only Demo')
      .execute(client);

    console.log(`Transaction ID: ${createTx.transactionId.toString()}`);
    const createReceipt = await createTx.getReceipt(client);
    const topicId = createReceipt.topicId;
    console.log(`Topic created with ID: ${topicId.toString()}`);

    // Get and display the initial topic info
    console.log('\n2. Initial topic configuration:');
    await displayTopicInfo(client, topicId);

    // Test sending a message to the topic with the Submit Key
    console.log('\n3. Testing message submission with the Submit Key...');
    await testMessageSubmission(client, topicId, submitKey);

    // Attempting to roll the Submit Key to a new Submit Key
    console.log('\n4. ATTEMPTING: Rolling Submit Key to a new value...');

    try {
      const updateSubmitKeyTx = await new TopicUpdateTransaction()
        .setTopicId(topicId)
        .setSubmitKey(newSubmitKey.publicKey)
        .freezeWith(client);

      // Sign with the current Submit Key
      const signedUpdateTx = await updateSubmitKeyTx.sign(submitKey);
      const updateResp = await signedUpdateTx.execute(client);
      await updateResp.getReceipt(client);

      console.log(
        '⚠️ Update transaction succeeded. Verifying if Submit Key was updated...'
      );
      await displayTopicInfo(client, topicId);

      // Test if the new Submit Key works
      console.log('\nTesting message submission with the new Submit Key...');
      const newKeyValid = await testMessageSubmission(
        client,
        topicId,
        newSubmitKey
      );

      if (newKeyValid) {
        console.log('✅ Submit Key successfully updated to new value');
      } else {
        console.log('❌ Submit Key update failed - new key not valid');
      }
    } catch (error) {
      console.log(`❌ Error updating Submit Key: ${error.message}`);
      console.log(
        '❌ This suggests Submit Key CANNOT update itself without an Admin Key'
      );
    }

    // Attempting to set the Submit Key to a dead key
    console.log(
      '\n5. ATTEMPTING: Setting Submit Key to a dead (unusable) key...'
    );

    try {
      const deadKey = createDeadKey();

      const updateToDeadKeyTx = await new TopicUpdateTransaction()
        .setTopicId(topicId)
        .setSubmitKey(deadKey)
        .freezeWith(client);

      // Use whichever key is currently valid
      const keyToUse = (await isSubmitKeyValid(client, topicId, newSubmitKey))
        ? newSubmitKey
        : submitKey;

      const signedDeadKeyTx = await updateToDeadKeyTx.sign(keyToUse);
      const updateDeadKeyResp = await signedDeadKeyTx.execute(client);
      await updateDeadKeyResp.getReceipt(client);

      console.log(
        '⚠️ Update to dead key transaction succeeded. Verifying if Submit Key is now unusable:'
      );
      await displayTopicInfo(client, topicId);

      // Test message submission which should fail with a dead key
      console.log('\nTesting message submission after updating to dead key...');
      await testMessageSubmission(client, topicId, null, true);
    } catch (error) {
      console.log(`❌ Error setting dead Submit Key: ${error.message}`);
      console.log(
        '❌ This suggests Submit Key CANNOT be set to a dead key without an Admin Key'
      );
    }

    console.log('\nTEST 1 SUMMARY:');
    // Determine outcome based on previous tests
    if (
      (await isSubmitKeyValid(client, topicId, submitKey)) ||
      (await isSubmitKeyValid(client, topicId, newSubmitKey))
    ) {
      console.log(
        '❌ Submit Key CANNOT be made immutable without an Admin Key'
      );
      console.log(
        '❌ This means topics without Admin Keys cannot transition to immutable state'
      );
    } else {
      console.log('✅ Submit Key CAN be made immutable without an Admin Key');
      console.log(
        '✅ This means topics can transition to immutability through dead keys'
      );
    }
  } catch (error) {
    console.error('Error in Submit Key Only test:', error);
    console.error('Detailed error:', JSON.stringify(error, null, 2));
  }
}
```

This will log the following:

```
TEST 1: SUBMIT KEY ONLY - CAN IT BE MADE IMMUTABLE?
Generating demo keys

1. Creating a topic with ONLY a Submit Key (no Admin Key)...
Transaction ID: 0.0.2659396@1741703167.853011465
Topic created with ID: 0.0.5686216

2. Initial topic configuration:
Topic Info:
- Topic ID: 0.0.5686216
- Topic Memo: Submit Key Only Demo
- Admin Key Present: false
- Submit Key Present: true
- Expiry Time: Mon Jun 09 2025 10:26:12 GMT-0400 (Eastern Daylight Time)

3. Testing message submission with the Submit Key...
✅ Message submitted successfully

4. ATTEMPTING: Rolling Submit Key to a new value...
❌ Error updating Submit Key: receipt for transaction 0.0.2659396@1741703170.795472325 contained error status UNAUTHORIZED
❌ This suggests Submit Key CANNOT update itself without an Admin Key

5. ATTEMPTING: Setting Submit Key to a dead (unusable) key...
❌ Error setting dead Submit Key: receipt for transaction 0.0.2659396@1741703173.060464361 contained error status UNAUTHORIZED
❌ This suggests Submit Key CANNOT be set to a dead key without an Admin Key

TEST 1 SUMMARY:
❌ Submit Key CANNOT be made immutable without an Admin Key
❌ This means topics without Admin Keys cannot transition to immutable state
```

Thus: 

- Submit keys cannot be rolled to dead keys to make them fully immutable. 
- Admin keys cannot be rolled to dead keys because the transaction has to be signed with the new admin key. 
- It is not possible to create an immutable topic id. 

## Why This Matters

Many applications require truly immutable topics, but currently:
- Topics created with keys cannot transition to immutability
- Empty KeyList approach makes topics public/writable (undesirable)
- No way to permanently prevent message submissions

## Implementation Notes

- Fully backward compatible
- Opt-in functionality
- No migration required for existing topics
- New SDK methods for dead key support

## Related Issues/HIPs

- Builds on concepts from [HIP-540](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-540.md)
- Addresses long-standing community requests for topic immutability