### PR TITLE
make explicit callData not ethereuData is jumbo

### DIFF
--- a/HIP/hip-1086.md
+++ b/HIP/hip-1086.md
@@ -14,14 +14,14 @@ created: 2024-11-20
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/discussions/1085
 hedera-reviewed-date: 2025-03-18
 hedera-approval-status: Approved
-updated: 2025-03-24
+updated: 2025-04-24
 requires: 1084
 ---
 
 ## Abstract
 
-This HIP introduces and supports "jumbo" Ethereum transactions by setting the the size of [EthereumTransaction.ethereum_data](https://github.com/hashgraph/hedera-protobufs/blob/main/services/ethereum_transaction.proto#L69)`
-to a configurable upper limit, and increases the limit on the total size of `EthereumTransaction` types from 6KB to a 
+This HIP introduces and supports "jumbo" Ethereum transactions by setting a configurable upper limit of the `callData`
+field of an RLP encoded Ethereum transaction found in [EthereumTransaction.ethereum_data](https://github.com/hashgraph/hedera-protobufs/blob/main/services/ethereum_transaction.proto#L69), and increasing the limit on the total size of `EthereumTransaction` types from 6KB to a 
 configurable upper limit. It also introduces a new throttle bucket that represents the max bytes-per-second for
 accepting these "jumbo" transactions larger than 6KB on the network, such that each node gets 1/N of the jumbo
 throttle bucket (using our existing throttle system).
@@ -32,14 +32,14 @@ Ethereum and other EVM networks permit significantly larger amounts of data in a
 whereas all Hiero transactions are capped at 6KB. Smart contracts that are larger than 6KB have to be uploaded 
 to the Hiero File Service (HFS) through a `FileCreate` transaction followed by multiple `FileAppend` 
 transactions. Not only does this lead to a poor developer experience, but it makes operating a JSON-RPC relay 
-difficult and expensive. Allowing `ethereum_data` in excess of 6KB provides parity with most non-rollup use cases.  
+difficult and expensive. Allowing `callData` in excess of 6KB provides parity with most non-rollup use cases.  
 Enabling single-transaction parity with most Ethereum smart contracts and calls improves  
 compatibility, developer experience, and makes it easier to operate a JSON-RPC relay.
 
 ## Rationale
 
 Hiero limits all transactions to a maximum size of 6KB. By limiting the size of transactions, Hiero makes it easier
-for clients to get fair access to the network. Ethereum, on the other hand, supports much larger callData 
+for clients to get fair access to the network. Ethereum, on the other hand, supports much larger `callData` 
 sizes. The 6KB limit is highly problematic for developer experience, and unexpectedly, for network efficiency. This 
 is especially true when creating contracts, and for oracles sending large amounts of data to the network.
 
@@ -72,8 +72,8 @@ makes access to cheap relays difficult.
 
 ## Specification
 
-- Permit EthereumTransaction `ethereum_data` max size to be configurable but not exceed a specified upper limit in KBs
-- The entire transaction, including signatures, may exceed 6KB but shall not exceed a configurable upper limit in KBs
+- Permit `callData` max size to be configurable but not exceed a specified upper limit in KBs
+- The entire `EthereumTransaction`, including signatures, may exceed 6KB but shall not exceed a configurable upper limit in KBs
 - Institute a network-wide throttle on bytes-per-second for "jumbo" EthereumTransactions larger than 6KB.
 
 ### Execution
@@ -154,6 +154,14 @@ The configured event size must be large enough to allow at least 1 jumbo transac
 With this HIP, the behavior of Ethereum transactions will better match expectations for Ethereum developers. There
 should be documentation added to docs.hedera.com to cover this and the documentation for the SDKs should be
 updated. The main point to be described to users will be how the jumbo transactions are priced and throttled.
+
+## Rejected Ideas
+Expansion to `ContractCreate` and `ContractCall` transactions: The notion of applying similar changes in this HIP for 
+`ContractCreate` and `ContractCall` transactions was considered but due to the existing logic of hbar payments which
+align with normal network behaviour it was deemed not essential for inclusion in this HIP. Additionally, the main pain 
+points are felt by users of the `EthereumTrasaction`.
+It is still worth consideration and could be brought up in a separate HIP.
+
 
 ## References
 


### PR DESCRIPTION
**Description**:
Minor draft updates in wording to make it more explicit `callData` is the jumbo part of the HIP

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Will not be checked in and if just capturing thoughts for usage by @Ferparishuertas 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
