### PR TITLE
chore: Update Contract Service output and trace specification

### DIFF
--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -3,7 +3,7 @@ hip: 1056
 title: Block Streams
 author: >-
   Jasper Potts <@jasperpotts>, Richard Bair <@rbair23>, Nana Essilfie-Conduah <@Nana-EC>,
-  Mark Blackman <mark@swirldslabs.com>, Edward Wertz<@edward-swirldslabs>
+  Mark Blackman <mark@swirldslabs.com>, Edward Wertz<@edward-swirldslabs>, Michael Tinker <@tinker-michaelj> 
 working-group: >-
   Jasper Potts <@jasperpotts>, Richard Bair <@rbair23>, Nana Essilfie-Conduah <@Nana-EC>,
   Mark Blackman <mark@swirldslabs.com>, Leemon Baird, Joseph Sinclair <@jsync-swirlds>, Nick Poorman <@nickpoorman>,
@@ -488,11 +488,12 @@ information. Another service could filter on only accounts they are interested i
 stream are represented by one or more `FilteredItemHash`’s which provide the missing hashes required to validate the
 filtered stream with the same block proof as the full stream.
 
-> The parent-child relationship of some transactions is preserved in the Block Streams and will see the appropriate
+The parent-child relationship of some transactions is preserved in the Block Streams and will see the appropriate
 `BlockItem`s for each level. For example a `CryptoTransfer` transaction to a non existing EVM address results in the
-auto creation of a new Account with the said EVM address. In the Block Streams the `CryptoTransfer` transaction will be described by its `EventTransaction`, `TransactionResult`, `TransactionOutput` and `StateChange` `BlockItem`s. The
-`CryptoCreate` transaction will also be described by its own `EventTransaction`, `TransactionResult`, `TransactionOutput
-and `StateChange` `BlockItem`s. In this way a transactions input, output and impacts on the network are clearly described.
+auto creation of a new Account with the said EVM address. In the Block Streams the `CryptoTransfer` transaction will
+be described by its `EventTransaction`, `TransactionResult`, `TransactionOutput` and `StateChange` `BlockItem`s. The
+`CryptoCreate` transaction will also be described by its own `EventTransaction`, `TransactionResult`, `TransactionOutput`
+and `StateChange` `BlockItem`s. In this way a transactions input, output and impacts on the networkare clearly described.
 
 #### BlockHeader
 
@@ -820,20 +821,28 @@ message TransactionOutput {
 ```
 
 ```protobuf
-message ContractCallOutput {
+message CallContractOutput {
+    // Preview block streams used this field for sidecars
+    reserved 1;
+
     /**
-     * Result details for an EVM transaction execution
+     * An EVM transaction result. Contains just the information not already
+     * externalized in the matching transaction body.
      */
-    EVMTransactionResult evm_transaction_result = 1;
+    proto.EvmTransactionResult evm_transaction_result = 2;
 }
 ```
 
 ```protobuf
-message ContractCreateOutput {
+message CreateContractOutput {
+    // Preview block streams used this field for sidecars
+    reserved 1;
+
     /**
-     * Result details for an EVM transaction execution
+     * An EVM transaction result. Contains just the information not already
+     * externalized in the matching transaction body.
      */
-    EVMTransactionResult evm_transaction_result = 1;
+    proto.EvmTransactionResult evm_transaction_result = 2;
 }
 ```
 
@@ -848,10 +857,33 @@ message CreateAccountOutput {
 
 ```protobuf
 message EthereumOutput {
+   // Preview block streams used these fields for sidecars and verbose
+   // contract function results
+   reserved 2,3,4;
+
     /**
-     * Result details for an EVM transaction execution
+     * If the associated Ethereum transaction required hydrating its
+     * call data from a file, the Keccak256 hash of the transaction.
+     * <p>
+     * If the Ethereum transaction was inline, this field SHALL NOT be set.
      */
-    EVMTransactionResult evm_transaction_result = 1;
+    bytes ethereum_hash = 1;
+
+    oneof txn_result {
+        /**
+         * An EVM transaction result for an Ethereum transaction executed as a
+         * call. Contains just the information not already externalized in the
+         * matching transaction body.
+         */
+        proto.EvmTransactionResult evm_call_transaction_result = 5;
+
+        /**
+         * An EVM transaction result for an Ethereum transaction executed as a
+         * create. Contains just the information not already externalized in the
+         * matching transaction body.
+         */
+        proto.EvmTransactionResult evm_create_transaction_result = 6;
+    }
 }
 ```
 
@@ -1720,116 +1752,177 @@ however every byte of information is stored fore er and needed in the proof of t
 to ensure that data is required but also laid out in a way that makes it easier for filtering by downstream clients.
 To this point the `TraceData` would initially contain smart contracts `EVMTraceData` that support traceability information (e.g.
 contract actions, read values etc). Future trace like data can be added to `TraceData` and Block Nodes, Mirror Nodes and
-other block stream parsign clients can decided to store or filter it out based on their needs.
+other block stream clients can decided to store or filter it out based on their needs.
 
 ```protobuf
-message ContractSlotReads {
-     
-     message SlotRead {
-          oneof identifier {
-               /**
-               * The contract storage slot counter in this block 
-               * This is populated in place of the 256 bit word when the given slot is written to in state changes
-               */
-               int32 index = 1;
+/**
+ * EVM trace data, including:
+ * 1. Initcode used for any internal contract creations.
+ * 2. Contract actions executed during the transaction (i.e., the call trace)
+ * 3. Contract slot usages, including reads and writes.
+ * 4. Events logged during the transaction.
+ * 5. Full error message, if any, produced by the contract call.
+ */
+message EVMTraceData {
+    /**
+     * The initcode of child contracts created during execution.
+     */
+    repeated ContractInitcode initcodes = 1;
 
-               /**
-               * The key of this contratc storage slot, may be left-padded with zeros to form a 256-bit word.
-               * This is populated when the slot was not written and only read
-               */
-               bytes key = 2;
-          }
+    /**
+     * All contract actions executed during the transaction.
+     */
+    repeated proto.ContractAction contract_actions = 2;
 
-          /**
-          * The storage value in this slot, may be left-padded with zeros to form a 256-bit word.
-          */
-          bytes read_value = 3;
-     }
-     
-     /**
-      * The contract associated with the storage slots this slot belongs to.
-      */
-     ContractID contract_id = 1;
+    /**
+     * Contract slot usages in the transaction, by contract id.
+     */
+    repeated ContractSlotUsage contract_slot_usages = 3;
 
-     /**
-      * The storage slots that were read in this EVM exectuion. They may or may not have assocaited slot writes
-      */
-     repeated SlotRead slot_reads = 2;    
+    /**
+     * Log events produced during the transaction, by contract id.
+     */
+    repeated EvmTransactionLog logs = 4;
+
+    /**
+     * Additional details of any error message in the EVM transaction result.
+     * <p>
+     * This SHALL be unset if the contract call succeeded.
+     */
+    string error_details = 5;
 }
 
 /**
- * EVM transaction execution log storage details
- * Details maps to the log object in eth_getTransactionReceipt response without repeating info already available in the input transaction
- * Log bloom logic is removed as it may be calculated by block parser for both transactions and block level
+ * Usage of a contract's storage slots in an EVM transaction.<br/>
  */
-message EVMTransactionLog {
-     /**
-      * The contract emitting the log. ContractID vs 20 bye address is used to preserve space
-      */
-     ContractID contract_id = 1;
+message ContractSlotUsage {
+    /**
+     * The contract using the storage slots.
+     */
+    proto.ContractID contract_id = 1;
 
-     /**
-      * The Log data
-      */
-     bytes data = 2;
+    /**
+     * The storage slots that were written to in the EVM transaction.
+     * <p>
+     * The written value can be unambiguously derived from the block items
+     * in this EVM transaction's Hiero transactional unit. In particular,
+     * 1. If a following EVM trace modifies the same slot, the value written
+     * in this EVM transaction was whatever value the following trace read.
+     * 2. If the slot was not modified in a following EVM trace, the value
+     * is whatever value was committed to the Merkle state for the slot.
+     */
+    repeated bytes written_slot_keys = 2;
 
-     /**
-      * The logc topics left padding of 0's by EVM is stripped to save space. 
-      * Indexers should left-pad with zeros to form a 256-bit word.
-      */
-     repeated bytes topics = 3;
+    /**
+     * The storage slots that were read in this EVM execution. They may or
+     * may not have associated slot writes.
+     */
+    repeated SlotRead slot_reads = 3;
 }
 
 /**
- * The init bytecode components for child contracts created as part of the contract execution.
- * init_bytecode = deploy_bytecode + runtime_byteode + metadata_bytecode
+ * A slot read in a contract's storage, as used in an EVM transaction.<br/>
  */
-message ContractInitByteCode {
-    /**
-     * The bytecode that predeces and deploys the runtime bytecode in a contracts deployment
-     */
-    google.protobuf.BytesValue deploy_bytecode = 1;
+message SlotRead {
+    oneof identifier {
+        /**
+        * If this slot was also written, the index of the written key in the
+        * ContractSlotUsage#slot_writes list above.
+        */
+        int32 index = 1;
+
+        /**
+        * If this slot was only read, its key; may be left-padded with zeros to 32 bytes.
+        */
+        bytes key = 2;
+    }
 
     /**
-     * The bytecode that follows the runtime bytecode (found in contract state) in a contracts deployment.
-     */
-    google.protobuf.BytesValue metadata_bytecode = 2;
-
-    /**
-     * The bytecode that defines a deployed contracts logic. Only present if not in state.
-     */
-    google.protobuf.BytesValue runtime_bytecode = 3;
+    * The storage value in this slot, may be left-padded with zeros to 32 bytes.
+    */
+    bytes read_value = 3;
 }
 
 /**
- * EVM tranaction execution trace details
- * Details maps to the variable needed for debugging executions
+ * Information about the initcode of a contract whose creation was attempted
+ * during the EVM transaction.
  */
-message EVMTraceData { 
+message ContractInitcode {
+    oneof code {
+        /**
+         * The initcode used for a failed top-level creation.
+         */
+        bytes failed_initcode = 2;
+
+        /**
+         * The initcode "bookends" around a newly created contract's runtime bytecode.
+         */
+        ExecutedInitcode executed_initcode = 3;
+    }
+}
+
+/**
+  * Information about the initcode executed to create a contract.
+ */
+message ExecutedInitcode {
     /**
-     * The init bytecode component for this child contract created as part of the contract execution.
+     * The id of the contract created by the initcode.
      */
-    ContractInitByteCode init_bytecode = 1;
+    proto.ContractID contract_id = 1;
+
+    oneof initcode {
+        /**
+         * If the runtime bytecode follows the common convention of appearing as a subsequence
+         * of the initcode, the initcode pieces that surround the runtime bytecode (which is
+         * necessarily in the Hiero transactional unit's state changes).
+         */
+        InitcodeBookends initcode_bookends = 2;
+
+        /**
+         * If the runtime bytecode is not a subsequence of the initcode, the explicit initcode.
+         */
+        bytes explicit_initcode = 3;
+    }
+}
+
+/**
+  * The initcode bookends of a contract, which are the deploy bytecode and metadata
+  * bytecode that surround the runtime bytecode in a contract's deployment.
+  * <p>
+  * The runtime bytecode is not included here, as it is externalized via a state change
+  * with the matching contract id in the Hiero transactional unit.
+ */
+message InitcodeBookends {
+    /**
+     * The bytecode that precedes the runtime bytecode of a contract in initcode.
+     */
+    bytes deploy_bytecode = 1;
 
     /**
-     * The inter contract interaction details. This represents the internal EVM message frames.
+     * The bytecode that follows the runtime bytecode of a contract in initcode.
      */
-    repeated ContractAction contract_actions = 2;    
- 
+    bytes metadata_bytecode = 2;
+}
+
+/**
+ * A EVM transaction log; c.f. eth_getTransactionReceipt.<br/>
+ * Stream consumers may compute bloom values from topics and data if desired.
+ */
+message EvmTransactionLog {
     /**
-     * Contract slot values that were read during the execution of the EVM transaction. Associated written values will be in state changes
+     * The contract emitting the log.
      */
-    repeated ContractSlotReads contract_slot_reads = 3;
+    proto.ContractID contract_id = 1;
 
     /**
-     * Any error message produced by the contract call.
+     * The logged data.
      */
-    string full_error_message = 4;
+    bytes data = 2;
 
     /**
-     * Any Log events produced by this contract call.
+     * The log's topics; may be left-padded with zeros to form 256-bit words.
      */
-    repeated EVMTransactionLog logs = 5;
+    repeated bytes topics = 3;
 }
 ```
 

--- a/assets/hip-1056/protobuf/stream/output/smart_contract_service.proto
+++ b/assets/hip-1056/protobuf/stream/output/smart_contract_service.proto
@@ -1,5 +1,5 @@
 /**
- * #  Service
+ * # Smart Contract Service
  * Block stream messages that report the results of transactions handled
  * by the `smart contract` service.
  *
@@ -15,12 +15,71 @@ syntax = "proto3";
 package com.hedera.hapi.block.stream.output;
 
 // SPDX-License-Identifier: Apache-2.0
-
 option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-import "contract_call_local.proto";
+import "services/contract_types.proto";
+
+// <<<START new types from services/contract_types.proto>>>
+/**
+ * Context of an internal call in an EVM transaction that is not otherwise externalized.<br/>
+ */
+message InternalCallContext {
+    /**
+     * The gas available for the call.<br/>
+     */
+    uint64 gas = 1;
+
+    /**
+     * The value sent with the call.<br/>
+     */
+    uint64 value = 2;
+
+    /**
+     * The call data for the call.<br/>
+     */
+    bytes call_data = 3;
+}
+
+/**
+ * Results of executing a EVM transaction.<br/>
+ */
+message EvmTransactionResult {
+    /**
+     * The Hedera id of the caller.<br/>
+     */
+    AccountID sender_id = 1;
+
+    /**
+     * The Hedera id of the contract receiving the call.<br/>
+     */
+    ContractID contract_id = 2;
+
+    /**
+     * Result data from the function call.
+     */
+    bytes result_data = 3;
+
+    /**
+     * Any error message produced by the contract call. Max size of 100 bytes.
+     * <p>
+     * This SHALL be unset if the contract call succeeded.
+     */
+    string error_message = 4;
+
+    /**
+     * EVM gas used.
+     */
+    uint64 gas_used = 5;
+
+    /**
+     * If not already externalized in a transaction body, the context of the
+     * internal call producing this result.
+     */
+    InternalCallContext internal_call_context = 6;
+}
+// <<<END new types from services/contract_types.proto>>>
 
 /**
  * Block Stream data for a `contractCallMethod` transaction.
@@ -28,11 +87,15 @@ import "contract_call_local.proto";
  * This message SHALL NOT duplicate information already contained in
  * the original transaction.
  */
-message ContractCallOutput {
-     /**
-      * Result details for an EVM transaction execution
-      */
-     EVMTransactionResult evm_transaction_result = 1;
+message CallContractOutput {
+    // Preview block streams used this field for sidecars
+    reserved 1;
+
+    /**
+     * An EVM transaction result. Contains just the information not already
+     * externalized in the matching transaction body.
+     */
+    proto.EvmTransactionResult evm_transaction_result = 2;
 }
 
 /**
@@ -41,37 +104,16 @@ message ContractCallOutput {
  * This message SHALL NOT duplicate information already contained in
  * the original transaction.
  */
-message ContractCreateOutput {
-     /**
-      * Result details for an EVM transaction execution
-      */
-     EVMTransactionResult evm_transaction_result = 1;
+message CreateContractOutput {
+    // Preview block streams used this field for sidecars
+    reserved 1;
+
+    /**
+     * An EVM transaction result. Contains just the information not already
+     * externalized in the matching transaction body.
+     */
+    proto.EvmTransactionResult evm_transaction_result = 2;
 }
-
-// no evm exec, only modified entity
-/**
- * Block Stream data for a `deleteContract` transaction.
- *
- * This message SHALL NOT duplicate information already contained in
- * the original transaction.
- */
-message ContractDeleteOutput {}
-
-/**
- * Block Stream data for a contract `systemUndelete` transaction.
- *
- * This message SHALL NOT duplicate information already contained in
- * the original transaction.
- */
-message ContractSystemUnDeleteOutput {}
-
-/**
- * Block Stream data for a contract `systemDelete` transaction.
- *
- * This message SHALL NOT duplicate information already contained in
- * the original transaction.
- */
-message ContractSystemDeleteOutput {}
 
 // no evm exec, only modified entity
 /**
@@ -80,8 +122,33 @@ message ContractSystemDeleteOutput {}
  * This message SHALL NOT duplicate information already contained in
  * the original transaction.
  */
- message ContractUpdateOutput {}
- 
+message UpdateContractOutput {}
+
+// no evm exec, only modified entity
+/**
+ * Block Stream data for a `deleteContract` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteContractOutput {}
+
+/**
+ * Block Stream data for a contract `systemUndelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SystemUnDeleteContractOutput {}
+
+/**
+ * Block Stream data for a contract `systemDelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SystemDeleteContractOutput {}
+
 /**
  * Block Stream data for a `callEthereum` transaction.
  *
@@ -89,186 +156,31 @@ message ContractSystemDeleteOutput {}
  * the original transaction.
  */
 message EthereumOutput {
-     /**
-      * Result details for an EVM transaction execution
-      */
-     EVMTransactionResult evm_transaction_result = 1;
-}
+   // Preview block streams used these fields for sidecars and verbose
+   // contract function results
+   reserved 2,3,4;
 
-/**
- * EVM transaction details
- * Details support the information needed by eth_getTransactionReceipt not found in or state changes
- * <p>
- * Values here map to the historic ContractFunction results in the record stream format.
- * The following optimizations were made
- * 1. contract_nonces and signer_nonce are noted restated. These updates will be exposed in the State changes.
- *   The impact is nonce values between transactions are not exposed, this block level concept matches EVM behaviour
- * 2. evm_addresses of newly created accounts or contracts are not restated as they are in state changes
- * 3. gas is not restated as it can be found in the RLP transaction or explicitly in the transactionbody input
- * 4. amount is not restated as it can be found in the RLP transaction or explicitly in the transactionbody input
- * 5. functionParameters is not restated as it's in the RLP transaction.
- *   For inner transactions this shall be in the ContractCall or ContractCreate
- * 6. sender_id is not restated as it can be found and transformed from the RLP transaction
- * 7. ContractID is not restated as it can be found in the RLP transaction or explicitly in the transactionbody input
- */
-message EVMTransactionResult {
-     /**
-      * Result data from the function call.
-      * <p>
-      * This SHALL be encoded in RLP bytecode format.
-      */
-     bytes contract_call_result = 1;
+    /**
+     * If the associated Ethereum transaction required hydrating its
+     * call data from a file, the Keccak256 hash of the transaction.
+     * <p>
+     * If the Ethereum transaction was inline, this field SHALL NOT be set.
+     */
+    bytes ethereum_hash = 1;
 
-     /**
-      * Any error message produced by the contract call. Max size of 100 bytes
-      * <p>
-      * This SHALL be unset if the contract call succeeded.
-      */
-     string error_message = 2;
+    oneof txn_result {
+        /**
+         * An EVM transaction result for an Ethereum transaction executed as a
+         * call. Contains just the information not already externalized in the
+         * matching transaction body.
+         */
+        proto.EvmTransactionResult evm_call_transaction_result = 5;
 
-     /**
-      * A quantity of "gas" used.<br/>
-      * This represents the resource units expended to execute this
-      * contract call, and correlates to transaction costs.
-      */
-     uint64 gas_used = 3;
-}
-
-/**
- * The slots read during the contract execution. These slots may or may not have been overwritten.
- * The associated writes will be found in the state changes MapUpdateChange KVs
- */
-message ContractSlotReads {
-     
-     message SlotRead {
-          oneof identifier {
-               /**
-               * The contract storage slot counter in this block 
-               * This is populated in place of the 256 bit word when the given slot is written to in state changes
-               */
-               int32 index = 1;
-
-               /**
-               * The key of this contratc storage slot, left padding of 0's by EVM is stripped to save space. 
-               * Indexers should left-pad with zeros to form a 256-bit word.
-               * This is populated when the slot was not written and only read
-               */
-               bytes key = 2;
-          }
-
-          /**
-           * The storage value in this slot, left padding of 0's by EVM is stripped to save space. 
-           * Indexers should left-pad with zeros to form a 256-bit word.
-          */
-          bytes read_value = 3;
-     }
-     
-     /**
-      * The contract assocaited with the storage slots this slot belongs to.
-      */
-     ContractID contract_id = 1;
-
-     /**
-      * The storage slots that were read in this EVM exectuion. They may or may not have assocaited slot writes
-      */
-     repeated SlotRead slot_reads = 2;    
-}
-
-/**
- * EVM transaction execution log storage details
- * Details maps to the log object in eth_getTransactionReceipt response without repeating info already available in the input transaction
- * Log bloom logic is removed as it may be calculated by block parser for both transactions and block level
- */
-message EVMTransactionLog {
-     /**
-      * The contract emitting the log. ContractID vs 20 bye address is used to preserve space
-      */
-     ContractID contract_id = 1;
-
-     /**
-      * The Log data
-      */
-     bytes data = 2;
-
-     /**
-      * The logc topics left padding of 0's by EVM is stripped to save space. 
-      * Indexers should left-pad with zeros to form a 256-bit word.
-      */
-     repeated bytes topics = 3;
-}
-
-/**
- * The init bytecode component for this child contracts created as part of the contract execution.
- * init_bytecode = deploy_bytecode + runtime_byteode + metadata_bytecode
- * The ContrctID will be found in the state changes for the corecposing 
- * <p>
- * The EVM opcode operations expose the code input and output during a contract creation.
- * The consensus node logic should be able to pick up the diff in initbyte and runtime to define the deploy and
- * metadata bytecode.
- * Indexers would be able to build the full bytecode by combinining ContractInitByteCode with contract runtime bytecode
- */
-message ContractInitByteCode {
-     /**
-      * The bytecode that predeces and deploys the runtime bytecode in a contracts deployment
-      * <p>
-      * This bytecode should end in the first occurent of f3fe (RETURN & INVALID) opcodes in the init bytecode
-      */
-     google.protobuf.BytesValue deploy_bytecode = 1;
-
-     /**
-      * The bytecode that follows the runtime bytecode (found in contract state) in a contracts deployment.
-      * <p>
-      * This bytecode may be present depending on the compiler utilized or the nature of child contract creations
-      */
-     google.protobuf.BytesValue metadata_bytecode = 2;
-
-     /**
-      * The bytecode that defines a deployed contracts logic. 
-      * <p>
-      * This bytecode is usually found in state but in some
-      * scenarios it may be necessary to expose it when missing from state e.g. SELFDESTRUCT
-      */
-     google.protobuf.BytesValue runtime_bytecode = 3;
-}
-
-/**
- * EVM tranaction execution trace details
- * Details maps to the variable needed for debugging executions
-  * <p>
- * Values here map to the historic SideCar in the record stream format.
- * The following optimizations were made
- * 1. ContractStateChanges are retired as all state changes are now in the StateChanges
- * 2. ContractBytecode is retired as initcode is made avialble in the input and runtimebyte code is exposed in changes
- *   Inner contract creations will have ContractCreate transations whose input and state changes should also expose this
- *   Q: Are cases of FileID usage covered in the child cases. Can we get creative and refer to the top level FileID and maybe even byte indexes to avoid replication?
- * 3. ContractLoginfo is not reused but shrunk into EVMTransactionLog.
- * 4. ethereum_hash is removed as it may be calculated by block parsers and indexers
- */
-message EVMTraceData { 
-     /**
-      * The init bytecode components for child contracts created as part of the contract execution.
-      */
-     ContractInitByteCode init_bytecode = 1;
-
-     /**
-      * The inter contract interaction details. This represents the internal EVM message frames.
-      */
-     repeated ContractAction contract_actions = 2;
- 
-     /**
-      * Contract slot values that were read during the execution of the EVM transaction. Associated written values will be in state changes
-      */
-     repeated ContractSlotReads contract_slot_reads = 3;
-
-     /**
-      * Any error message produced by the contract call.
-      * <p>
-      * This SHALL be unset if the contract call succeeded.
-      */
-     string full_error_message = 4;
-
-     /**
-      * Any Log events produced by this contract call.
-      */
-     repeated EVMTransactionLog logs = 5;
+        /**
+         * An EVM transaction result for an Ethereum transaction executed as a
+         * create. Contains just the information not already externalized in the
+         * matching transaction body.
+         */
+        proto.EvmTransactionResult evm_create_transaction_result = 6;
+    }
 }

--- a/assets/hip-1056/protobuf/stream/trace/smart_contract_service.proto
+++ b/assets/hip-1056/protobuf/stream/trace/smart_contract_service.proto
@@ -1,0 +1,196 @@
+/**
+ * # Smart Contract Service
+ * Block stream messages that report the trace data of transactions handled
+ * by the `smart contract` service.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.trace;
+
+// SPDX-License-Identifier: Apache-2.0
+option java_package = "com.hedera.hapi.block.stream.trace.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.trace">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "services/basic_types.proto";
+import "services/contract_types.proto";
+import "streams/sidecar_file.proto";
+import "streams/contract_action.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * Usage of a contract's storage slots in an EVM transaction.<br/>
+ */
+message ContractSlotUsage {
+    /**
+     * The contract using the storage slots.
+     */
+    proto.ContractID contract_id = 1;
+
+    /**
+     * The storage slots that were written to in the EVM transaction.
+     * <p>
+     * The written value can be unambiguously derived from the block items
+     * in this EVM transaction's Hiero transactional unit. In particular,
+     * 1. If a following EVM trace modifies the same slot, the value written
+     * in this EVM transaction was whatever value the following trace read.
+     * 2. If the slot was not modified in a following EVM trace, the value
+     * is whatever value was committed to the Merkle state for the slot.
+     */
+    repeated bytes written_slot_keys = 2;
+
+    /**
+     * The storage slots that were read in this EVM execution. They may or
+     * may not have associated slot writes.
+     */
+    repeated SlotRead slot_reads = 3;
+}
+
+/**
+ * A slot read in a contract's storage, as used in an EVM transaction.<br/>
+ */
+message SlotRead {
+    oneof identifier {
+        /**
+        * If this slot was also written, the index of the written key in the
+        * ContractSlotUsage#slot_writes list above.
+        */
+        int32 index = 1;
+
+        /**
+        * If this slot was only read, its key; may be left-padded with zeros to 32 bytes.
+        */
+        bytes key = 2;
+    }
+
+    /**
+    * The storage value in this slot, may be left-padded with zeros to 32 bytes.
+    */
+    bytes read_value = 3;
+}
+
+/**
+ * Information about the initcode of a contract whose creation was attempted
+ * during the EVM transaction.
+ */
+message ContractInitcode {
+    oneof code {
+        /**
+         * The initcode used for a failed top-level creation.
+         */
+        bytes failed_initcode = 2;
+
+        /**
+         * The initcode "bookends" around a newly created contract's runtime bytecode.
+         */
+        ExecutedInitcode executed_initcode = 3;
+    }
+}
+
+/**
+  * Information about the initcode executed to create a contract.
+ */
+message ExecutedInitcode {
+    /**
+     * The id of the contract created by the initcode.
+     */
+    proto.ContractID contract_id = 1;
+
+    oneof initcode {
+        /**
+         * If the runtime bytecode follows the common convention of appearing as a subsequence
+         * of the initcode, the initcode pieces that surround the runtime bytecode (which is
+         * necessarily in the Hiero transactional unit's state changes).
+         */
+        InitcodeBookends initcode_bookends = 2;
+
+        /**
+         * If the runtime bytecode is not a subsequence of the initcode, the explicit initcode.
+         */
+        bytes explicit_initcode = 3;
+    }
+}
+
+/**
+  * The initcode bookends of a contract, which are the deploy bytecode and metadata
+  * bytecode that surround the runtime bytecode in a contract's deployment.
+  * <p>
+  * The runtime bytecode is not included here, as it is externalized via a state change
+  * with the matching contract id in the Hiero transactional unit.
+ */
+message InitcodeBookends {
+    /**
+     * The bytecode that precedes the runtime bytecode of a contract in initcode.
+     */
+    bytes deploy_bytecode = 1;
+
+    /**
+     * The bytecode that follows the runtime bytecode of a contract in initcode.
+     */
+    bytes metadata_bytecode = 2;
+}
+
+/**
+ * A EVM transaction log; c.f. eth_getTransactionReceipt.<br/>
+ * Stream consumers may compute bloom values from topics and data if desired.
+ */
+message EvmTransactionLog {
+    /**
+     * The contract emitting the log.
+     */
+    proto.ContractID contract_id = 1;
+
+    /**
+     * The logged data.
+     */
+    bytes data = 2;
+
+    /**
+     * The log's topics; may be left-padded with zeros to form 256-bit words.
+     */
+    repeated bytes topics = 3;
+}
+
+/**
+ * EVM trace data, including:
+ * 1. Initcode used for any internal contract creations.
+ * 2. Contract actions executed during the transaction (i.e., the call trace)
+ * 3. Contract slot usages, including reads and writes.
+ * 4. Events logged during the transaction.
+ * 5. Full error message, if any, produced by the contract call.
+ */
+message EVMTraceData {
+    /**
+     * The initcode of child contracts created during execution.
+     */
+    repeated ContractInitcode initcodes = 1;
+
+    /**
+     * All contract actions executed during the transaction.
+     */
+    repeated proto.ContractAction contract_actions = 2;
+
+    /**
+     * Contract slot usages in the transaction, by contract id.
+     */
+    repeated ContractSlotUsage contract_slot_usages = 3;
+
+    /**
+     * Log events produced during the transaction, by contract id.
+     */
+    repeated EvmTransactionLog logs = 4;
+
+    /**
+     * Additional details of any error message in the EVM transaction result.
+     * <p>
+     * This SHALL be unset if the contract call succeeded.
+     */
+    string error_details = 5;
+}


### PR DESCRIPTION
**Description**:
 - Updates the spec for the normalized and deduplicated Smart Contract trace and output data.
 - The V6 record stream is proven to be recoverable from these block stream items; please see the PRs closing the sub-issues of [this](https://github.com/hiero-ledger/hiero-consensus-node/issues/19331) issue. 
   * For 100% fidelity in recovering the legacy `ContractFunctionResult#contract_nonces` field, a stream consumer does need to maintain the current nonce of each contract account; but the _goal_ for this `ContractFunctionResult#contract_nonces` field was only to keep stream consumers up-to-date on nonces; and this is trivially achieved using the block stream `StateChanges` now.