### PR TITLE
chore: Add `IHieroAccountAllowancePrePostHook` variant

### DIFF
--- a/HIP/hip-1195.md
+++ b/HIP/hip-1195.md
@@ -12,7 +12,7 @@ status: Approved
 last-call-date-time: 2025-06-06T07:00:00Z
 created: 2025-02-19
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/1172
-updated: 2025-06-12
+updated: 2025-07-11
 ---
 
 ## Abstract
@@ -780,25 +780,65 @@ messages used in the `CryptoTransferTransactionBody`.
 message AccountAmount {
   // ...
   /**
-   * If set, a call to a hook of type `ACCOUNT_ALLOWANCE_HOOK` present on the
-   * scoped account that must succeed for the containing CryptoTransfer to occur.
+   * If set, a call to a hook of type `ACCOUNT_ALLOWANCE_HOOK` on scoped
+   * account; the hook's invoked methods must not revert and must return
+   * true for the containing CryptoTransfer to succeed.
    */
-  HookCall allowance_hook_call = 4;
+  oneof hook_call {
+    /**
+     * A single call made before attempting the CryptoTransfer, to a
+     * method with logical signature allow(HookContext, ProposedTransfers)
+     */
+    HookCall pre_tx_allowance_hook = 4;
+    /**
+     * Two calls, the first call before attempting the CryptoTransfer, to a
+     * method with logical signature allowPre(HookContext, ProposedTransfers);
+     * and the second call after attempting the CryptoTransfer, to a method
+     * with logical signature allowPost(HookContext, ProposedTransfers).
+     */
+    HookCall pre_post_tx_allowance_hook = 5;
+  }
 }
 
 message NftTransfer {
   // ...
   /**
-   * If set, a call to a hook of type `ACCOUNT_ALLOWANCE_HOOK` present on the
-   * scoped account that must succeed for the containing CryptoTransfer to occur.
+   * If set, a call to a hook of type `ACCOUNT_ALLOWANCE_HOOK` installed on
+   * senderAccountID that must succeed for the transaction to occur.
    */
-  HookCall sender_allowance_hook_call = 5;
+  oneof sender_allowance_hook_call {
+    /**
+     * A single call made before attempting the CryptoTransfer, to a
+     * method with logical signature allow(HookContext, ProposedTransfers)
+     */
+    HookCall pre_tx_sender_allowance_hook = 5;
+    /**
+     * Two calls, the first call before attempting the CryptoTransfer, to a
+     * method with logical signature allowPre(HookContext, ProposedTransfers);
+     * and the second call after attempting the CryptoTransfer, to a method
+     * with logical signature allowPost(HookContext, ProposedTransfers).
+     */
+    HookCall pre_post_tx_sender_allowance_hook = 6;
+  }
 
   /**
-   * If set, a call to a hook of type `ACCOUNT_ALLOWANCE_HOOK` present on the
-   * scoped account that must succeed for the containing CryptoTransfer to occur.
+   * If set, a call to a hook of type `ACCOUNT_ALLOWANCE_HOOK` installed on
+   * receiverAccountID that must succeed for the transaction to occur.
    */
-  HookCall receiver_allowance_hook_call = 6;
+  oneof receiver_allowance_hook_call {
+    /**
+     * A single call made before attempting the CryptoTransfer, to a
+     * method with logical signature allow(HookContext, ProposedTransfers)
+     */
+    HookCall pre_tx_receiver_allowance_hook = 7;
+    /**
+     * Two calls, the first call before attempting the CryptoTransfer, to a
+     * method with logical signature allowPre(HookContext, ProposedTransfers);
+     * and the second call after attempting the CryptoTransfer, to a method
+     * with logical signature allowPost(HookContext, ProposedTransfers).
+     */
+    HookCall pre_post_tx_receiver_allowance_hook = 8;
+  }
 }
 ```
 
@@ -833,7 +873,7 @@ interface IHieroHook {
     }
 }
 
-/// The interface for an account allowance hook.
+/// The interface for an account allowance hook invoked once before a CryptoTransfer.
 interface IHieroAccountAllowanceHook {
     /// Combines HBAR and HTS asset transfers.
     struct Transfers {
@@ -863,6 +903,49 @@ interface IHieroAccountAllowanceHook {
        IHieroHook.HookContext calldata context,
        ProposedTransfers memory proposedTransfers
     ) external payable returns (bool);
+}
+
+/// The interface for an account allowance hook invoked both before and after a CryptoTransfer.
+interface IHieroAccountAllowancePrePostHook {
+   /// Combines HBAR and HTS asset transfers.
+   struct Transfers {
+      /// The HBAR transfers
+      IHederaTokenService.TransferList hbar;
+      /// The HTS token transfers
+      IHederaTokenService.TokenTransferList[] tokens;
+   }
+
+   /// Combines the full proposed transfers for a Hiero transaction,
+   /// including both its direct transfers and the implied HIP-18
+   /// custom fee transfers.
+   struct ProposedTransfers {
+      /// The transaction's direct transfers
+      Transfers direct;
+      /// The transaction's assessed custom fees
+      Transfers customFee;
+   }
+
+   /// Decides if the proposed transfers are allowed BEFORE the CryptoTransfer
+   /// business logic is performed, optionally in the presence of additional
+   /// context encoded by the transaction payer in the extra calldata.
+   /// @param context The context of the hook call
+   /// @param proposedTransfers The proposed transfers
+   /// @return true If the proposed transfers are allowed, false or revert otherwise
+   function allowPre(
+      IHieroHook.HookContext calldata context,
+      ProposedTransfers memory proposedTransfers
+   ) external payable returns (bool);
+   
+   /// Decides if the proposed transfers are allowed AFTER the CryptoTransfer
+   /// business logic is performed, optionally in the presence of additional
+   /// context encoded by the transaction payer in the extra calldata.
+   /// @param context The context of the hook call
+   /// @param proposedTransfers The proposed transfers
+   /// @return true If the proposed transfers are allowed, false or revert otherwise
+   function allowPost(
+      IHieroHook.HookContext calldata context,
+      ProposedTransfers memory proposedTransfers
+   ) external payable returns (bool);
 }
 ```
 
@@ -1034,6 +1117,8 @@ In progress, please see [here](https://github.com/hiero-ledger/hiero-consensus-n
    method needs to efficiently focus on one aspect of the proposed transfers.
 4. We considered support multiple charging schemes for hooks, such as `CALLER_PAYS` and `CALLER_PAYS_ON_FAILURE`.
    Ultimately it seemed better to keep the charging scheme simple and let hooks manage any refunds themselves.
+5. We considered not including the `IHieroAccountAllowancePrePostHook` option, but this left a gap in support for the
+   full range of HTS/ERC-20 integrations that Hedera users will likely be interested in.
 
 ## Open Issues
 


### PR DESCRIPTION
**Description**:
 - Opens the door to a range of HTS/ERC-20 integrations by adding a pre/post `TRANSFER_ALLOWANCE` hook.
    * For example, when a hook receives callbacks both before _and_ after its CryptoTransfer, in `allowPost()` it can validate the output leg of an ERC-20/ERC-20 swap it optimistically initiated in `allowPre()`.
