### PR TITLE
chore: Fix HIP-1215 system contract return values

### DIFF
--- a/HIP/hip-1215.md
+++ b/HIP/hip-1215.md
@@ -73,15 +73,16 @@ past the `expiry`, of course).
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | Hash        | Function signature                                                                                                                                                   |
 |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0x6f5bfde8  | scheduleCall(address to, uint256 expiry, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64 responseCode)                                            |
-| 0xeb459436  | scheduleCallWithSender(address to, address sender, uint256 expiry, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64 responseCode)                  |
-| 0x2c300715  | executeCallOnSenderSignature(address to, address sender, uint256 expiry, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64 responseCode)         |
-| 0x07cdefc0  | hasScheduleCapacity(uint256 expirySecond, uint256 gasLimit) view returns (bool capacity) |
+| 0x6f5bfde8  | scheduleCall(address to, uint256 expiry, uint256 gasLimit, uint64 value, bytes memory callData) returns (address)                                                    |
+| 0xeb459436  | scheduleCallWithSender(address to, address sender, uint256 expiry, uint256 gasLimit, uint64 value, bytes memory callData) returns (address)                          |
+| 0x2c300715  | executeCallOnSenderSignature(address to, address sender, uint256 expiry, uint256 gasLimit, uint64 value, bytes memory callData) returns (address)                    |
+| 0x07cdefc0  | hasScheduleCapacity(uint256 expirySecond, uint256 gasLimit) view returns (bool)                                                                                      |
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-The `scheduleCall()` variants revert with `SCHEDULE_EXPIRY_IS_BUSY` is the specified
-second is saturated. The `hasScheduleCapacity()` view function never reverts, but
+The `scheduleCall()` variants revert with reason `"SCHEDULE_EXPIRY_IS_BUSY"` if the given
+second is saturated. If they succeed, they return the address of the newly created
+scheduled transaction. The `hasScheduleCapacity()` view function never reverts, but
 returns `true` iff the given second still has capacity to schedule a contract call with
 the specified gas limit. 
 


### PR DESCRIPTION
**Description**:
 - The system contracts that create a new scheduled transaction on success should return the created schedule's address.