### PR TITLE
Update HIP-1139 to clarify the submit key update

### DIFF
--- a/HIP/hip-1139.md
+++ b/HIP/hip-1139.md
@@ -11,7 +11,7 @@ needs-hedera-approval: Yes
 needs-hiero-review: Yes
 discussions-to: https://github.com/hashgraph/hedera-improvement-proposal/pull/1139
 created: 2025-03-11
-updated: 2025-07-09
+updated: 2025-07-16
 ---
 
 ## Abstract
@@ -113,7 +113,6 @@ await new TopicUpdateTransaction()
    - A topic with both keys made unusable is fully immutable
    - A topic with Admin Key made unusable but with an active Submit Key has immutable administration but allows signed submissions
    - A topic with Submit Key set to a dead key but with an active Admin Key prevents message submissions but can be administratively updated
-   - Once a key is made unusable, it cannot be modified
 
 4. **HAPI Changes**:
    The TopicUpdate transaction will be modified to:
@@ -142,7 +141,7 @@ Our testing revealed several security considerations:
 1. **Key Management**:
 
    - Admin Key remains the highest privilege key until made unusable
-   - Dead keys and Admin Key immutability are permanent and irreversible
+   - Admin Key immutability are permanent and irreversible
    - Proper key custody remains critical until intentional transition to immutability
 
 2. **Attack Vectors**:


### PR DESCRIPTION
**Description**:
Updating the HIP-1139 to clarify that even if a submit key is set to `SENTINEL`, if we have an admin-key we can update it to a valid key