### PR TITLE
Change status of Accepted Application hips to Active

### DIFF
--- a/HIP/hip-11.md
+++ b/HIP/hip-11.md
@@ -5,7 +5,7 @@ author: Bryce Doganer (@BryceDoganer), Lucas Henning (@lucashenning)
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-02-23
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/49

--- a/HIP/hip-13.md
+++ b/HIP/hip-13.md
@@ -5,7 +5,7 @@ author: H. Bart <hbart.lit@gmail.com>
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-03-13
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/56

--- a/HIP/hip-179.md
+++ b/HIP/hip-179.md
@@ -5,7 +5,7 @@ author: Danno Ferrin <danno.ferrin@hedera.com>
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2021-12-21T07:00:00Z
 created: 2021-10-19
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/268

--- a/HIP/hip-19.md
+++ b/HIP/hip-19.md
@@ -3,7 +3,7 @@ hip: 19
 title: Decentralized Identifiers in Memo Fields
 author: Nick White <nick@recdefi.com>, Jonathan Padilla <jonathan@recdefi.com>, Atticus Francken <atticus@recdefi.com>, Steve Frenkel <steve@recdefi.com>, Alex McComb <alex@recdefi.com>, Daniel Norkin <daniel.norkin@envisionblockchain.com>
 type: Standards Track
-category: Application
+category: Active
 needs-council-approval: No
 status: Final
 created: 2021-06-07

--- a/HIP/hip-254.md
+++ b/HIP/hip-254.md
@@ -5,7 +5,7 @@ author: Soochul Yang <soochul.yang@gmail.com>
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-01-04T07:00:00Z
 created: 2021-12-01
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/292

--- a/HIP/hip-27.md
+++ b/HIP/hip-27.md
@@ -5,7 +5,7 @@ author: Jo Vercammen <jo.vercammen@meeco.me>
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-01-19T07:00:00Z
 created: 2021-06-06
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/103

--- a/HIP/hip-28.md
+++ b/HIP/hip-28.md
@@ -5,7 +5,7 @@ author: Matthew Smithies <matt.s@dovu.io>, Wes Geisenberger <wes.geisenberger@he
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Final
+status: Active
 created: 2021-10-10
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/83
 updated: 2021-10-27

--- a/HIP/hip-29.md
+++ b/HIP/hip-29.md
@@ -5,7 +5,7 @@ author: Daniel Norkin <daniel.norkin@envisionblockchain.com>
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Final
+status: Active
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/166
 created: 2021-10-11
 updated: 2021-10-11

--- a/HIP/hip-30.md
+++ b/HIP/hip-30.md
@@ -5,7 +5,7 @@ author: Danno Ferrin <danno.ferrin@hedera.com>
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2021-11-23T07:00:00Z
 created: 2021-10-11
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/169

--- a/HIP/hip-323.md
+++ b/HIP/hip-323.md
@@ -6,7 +6,7 @@ working-group: Greg Scullard <gregscullard@hedera.com>, Romain Menetrier <rm@emb
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-02-01T07:00:00Z
 created: 2021-12-09
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/325

--- a/HIP/hip-338.md
+++ b/HIP/hip-338.md
@@ -5,7 +5,7 @@ author: Daniel Akhterov <daniel@launchbadge.com>
 type: Standards Track 
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-02-22T07:00:00Z
 created: 2022-02-08
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/355

--- a/HIP/hip-478.md
+++ b/HIP/hip-478.md
@@ -5,7 +5,7 @@ author: John Conway (@scalemaildev), Walter Hernandez (@walter-hernandez), Mohsi
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-11-15T07:00:00Z
 created: 2022-05-17
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/479

--- a/HIP/hip-482.md
+++ b/HIP/hip-482.md
@@ -6,7 +6,7 @@ working-group: Daniel Ivanov <daniel-k-ivanov95@gmail.com>, Danno Ferrin <danno.
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2022-06-02T07:00:00Z
 created: 2022-05-19
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/488

--- a/HIP/hip-694.md
+++ b/HIP/hip-694.md
@@ -6,7 +6,7 @@ working-group: Nana Essilfie-Conduah<nana@swirldslabs.com>, Georgi Lazarov <geor
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2023-04-10T07:00:00Z
 created: 2023-03-13
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/695

--- a/HIP/hip-745.md
+++ b/HIP/hip-745.md
@@ -6,7 +6,7 @@ working-group: Simi Hunjan <@SimiHunjan>, Ognyan Chikov <@ochikov>, Peter Tonev 
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2023-07-28T07:00:00Z
 created: 2023-05-30
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/746

--- a/HIP/hip-775.md
+++ b/HIP/hip-775.md
@@ -6,7 +6,7 @@ working-group: Nana Essilfie-Conduah<nana@swirldslabs.com>, Ivo Yankov <ivo.yank
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2023-09-20T07:00:00Z
 created: 2023-08-02
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/774

--- a/HIP/hip-820.md
+++ b/HIP/hip-820.md
@@ -6,7 +6,7 @@ working-group: Jason Fabritz (@bugbytesinc), Milan Wiercx van Rhijn (@MilanWR), 
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2023-12-28T07:00:00Z
 created: 2023-10-05
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/819

--- a/HIP/hip-945.md
+++ b/HIP/hip-945.md
@@ -7,7 +7,7 @@ requested-by: keith.kowal@swirldslabs.com
 type: Standards Track
 category: Application
 needs-council-approval: No
-status: Accepted
+status: Active
 last-call-date-time: 2024-05-06T07:00:00Z
 created: 2024-04-01
 discussions-to: https://github.com/hashgraph/did-method/pull/4


### PR DESCRIPTION
As part of the work we did to migrate Hiero hips, we changed definitions of status on Application hips to be in alignment with Informational hips so instead of being Accepted, they are now Active.