### PR TITLE
fix: update return types for system contract calls to reflect implementation

### DIFF
--- a/HIP/hip-206.md
+++ b/HIP/hip-206.md
@@ -10,7 +10,7 @@ last-call-date-time: 2021-11-26T07:00:00Z
 release: v0.22.0
 created: 2021-11-04
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/208
-updated: 2022-04-26
+updated: 2025-07-31
 ---
 
 ## Abstract
@@ -95,28 +95,28 @@ and `tokenMint` returns the new NFT serial numbers if new NFTs are generated.
 
 The ABI signature and hashes for each call are as follows
 
-| hash       | signature                                                                 | return               |
-| ---------- | ------------------------------------------------------------------------- |----------------------|
-| `189a554c` | `cryptoTransfer((address,(address,int64)[],(address,address,int64)[])[])` | `(int)`              |
-| `82bba493` | `transferTokens(address,address[],int64[])`                               | `(int)`              |
-| `eca36917` | `transferToken(address,address,address,int64)`                            | `(int)`              |
-| `2c4ba191` | `transferNFTs(address,address[],address[],int64[])`                       | `(int)`              |
-| `5cfc9011` | `transferNFT(address,address,address,int64)`                              | `(int)`              |
-| `278e0b88` | `mintToken(address,uint64,bytes[])`                                       | `(int,uint64,int[])` |
-| `acb9cff9` | `burnToken(address,uint64,int64[])`                                       | `(int,uint64)`       |
-| `2e63879b` | `associateTokens(address,address[])`                                      | `(int)`              |
-| `49146bde` | `associateToken(address,address[])`                                       | `(int)`              |
-| `78b63918` | `dissociateTokens(address,address[])`                                     | `(int)`              |
-| `099794e8` | `dissociateToken(address,address[])`                                      | `(int)`              |
+| hash       | signature                                                                 | return                  |
+| ---------- | ------------------------------------------------------------------------- |-------------------------|
+| `189a554c` | `cryptoTransfer((address,(address,int64)[],(address,address,int64)[])[])` | `(int64)`               |
+| `82bba493` | `transferTokens(address,address[],int64[])`                               | `(int64)`               |
+| `eca36917` | `transferToken(address,address,address,int64)`                            | `(int64)`               |
+| `2c4ba191` | `transferNFTs(address,address[],address[],int64[])`                       | `(int64)`               |
+| `5cfc9011` | `transferNFT(address,address,address,int64)`                              | `(int64)`               |
+| `278e0b88` | `mintToken(address,uint64,bytes[])`                                       | `(int64,int64,int64[])` |
+| `acb9cff9` | `burnToken(address,uint64,int64[])`                                       | `(int64,int64)`         |
+| `2e63879b` | `associateTokens(address,address[])`                                      | `(int64)`               |
+| `49146bde` | `associateToken(address,address[])`                                       | `(int64)`               |
+| `78b63918` | `dissociateTokens(address,address[])`                                     | `(int64)`               |
+| `099794e8` | `dissociateToken(address,address[])`                                      | `(int64)`               |
 
 #### Atomic CryptoTransfer
 In order to enhance the functionality of the `cryptoTransfer` call an alternative form of the call will
 be supported with the following ABI signature and hash.
 
 
-| hash       | signature                                                                 | return               |
-| ---------- | ------------------------------------------------------------------------- |----------------------|
-| `0x0e71804f` | `cryptoTransfer(((address,int64,bool)[]),(address,(address,int64,bool)[],(address,address,int64,bool)[])[])` | `(int)`              |
+| hash         | signature                                                                                                    | return     |
+|--------------|--------------------------------------------------------------------------------------------------------------|------------|
+| `0x0e71804f` | `cryptoTransfer(((address,int64,bool)[]),(address,(address,int64,bool)[],(address,address,int64,bool)[])[])` |  `(int64)` |
 
 This enhanced version of the `cryptoTransfer` call supports the atomic transfers of hbars, fungible and non-fungible tokens.
 In addition it supports approved fund and token transfers


### PR DESCRIPTION
Many of the return types on HTS system contract functions in HIP-206 that reflect the response code do not reflect the current implementation. Correct the return types to mismatches.