### PR TITLE
Update HIP-1056: Remove middle signature bit

### DIFF
--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -622,22 +622,20 @@ to reconstruct `GossipEvent`s as needed for hashgraph reconstruction from the co
 that easy `EventHeader` includes the the `EventCore` that is part of `GossipEvent` and all transactions are defined 
 as`EventTransaction` which can be used unchanged to construct the original `GossipEvent`. 
 
-To save space in each block and in the block stream, the signature in a `GossipEvent` is replaced with a boolean 
-modeling the middle bit of the signature in the `EventHeader`. Trust that the event is authentic will come from the 
-block proof for the block containing the event.  The `EventHeader` will contain all the data necessary to 
-reconstruct the `GossipEvent` except for the original signature. The primary space-saving comes from replacing the 
-`EventDescriptors` used to indicate the parents of each event. If an `EventDescriptor` of a parent points to an 
-event outside the block, the `EventHeader` will continue to preserve the `EventDescriptor` that points to that 
-parent event.  If the parent is contained within this block, however, the `EventDescriptor` is replaced with a 
-`uint32` index that indicates which event from the start of the block is the parent event.  This index is 0 based. 
-The first few events from each node in each block will start out with `EventDescriptors` for parents outside the 
-block.  As the index increases, events will begin to have parents in the block.  Each `EventDescriptor` is 72 bytes 
-whereas each `uint32` is 4 bytes.  This space-saving is important for networks with low user transaction activity to 
+To save space in each block and in the block stream, the signature in a `GossipEvent` is removed. Trust that the event
+is authentic will come from the block proof for the block containing the event. The `EventHeader` will contain all the 
+data necessary to reconstruct the `GossipEvent` except for the original signature. The primary space-saving comes from 
+replacing the`EventDescriptors` used to indicate the parents of each event. If an `EventDescriptor` of a parent points 
+to an event outside the block, the `EventHeader` will continue to preserve the `EventDescriptor` that points to that
+parent event. If the parent is contained within this block, however, the `EventDescriptor` is replaced with a
+`uint32` index that indicates which event from the start of the block is the parent event. This index is 0 based.
+The first few events from each node in each block will start out with `EventDescriptors` for parents outside the
+block. As the index increases, events will begin to have parents in the block. Each `EventDescriptor` is 72 bytes
+whereas each `uint32` is 4 bytes. This space-saving is important for networks with low user transaction activity to
 minimize the space occupied by events not containing transactions.
 
-To reconstruct the `GossipEvent` from an `EventHeader`, set the signature in the `GossipEvent` to the byte 
-`(signature_middle_bit ? 255 : 0)`.  Then replace each parent reference index with the `EventDescriptor` of the 
-event at that index within the block.  This process is recursive.  In order to construct the hash in an 
+To reconstruct the `GossipEvent` from an `EventHeader`, replace each parent reference index with the `EventDescriptor` 
+of the event at that index within the block. This process is recursive.  In order to construct the hash in an 
 `EventDescriptor`, the `EventCore` data for the `EventHeader` at the given parent index, along with the 
 EventDescriptors of the event's parents and transactions in the event, must be serialized and hashed. If the 
 `EventHeader` contains no event indices for parents, the base case is reached and the `GossipEvent` can be 
@@ -661,11 +659,6 @@ message EventHeader {
      * A list of references to parent events. <br/>
      */
     repeated ParentEventReference parents = 2;
-
-    /**
-     * The middle bit of the node's signature on the event.<br/>
-     */
-    bool signature_middle_bit = 3;
 }
 
 /*


### PR DESCRIPTION
**Description**:
Due to the algorithm change for coin rounds implemented in [this PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/20501), blocks no longer need to keep the middle bit of an events signature.

**Related issue(s)**:

- Documentation update for https://github.com/hiero-ledger/hiero-consensus-node/issues/20483

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
