### PR TITLE
Fix regex syntax error in draft HIPs workflow

### DIFF
--- a/.github/workflows/update-draft-hips.yml
+++ b/.github/workflows/update-draft-hips.yml
@@ -132,7 +132,7 @@ jobs:
               }
               const hipFiles = pr.files.edges.filter(edge => {
                 const fileNode = edge.node;
-                const isNewHIPFile = /^HIP\\/hip-[a-zA-Z0-9-]+\\.md$/.test(fileNode.path); // New regex
+                const isNewHIPFile = /^HIP\/hip-[a-zA-Z0-9-]+\.md$/.test(fileNode.path);
                 return fileNode.changeType === 'ADDED' && isNewHIPFile;
               }).map(edge => edge.node);
 


### PR DESCRIPTION
## Summary
- Fixed SyntaxError: Invalid regular expression flags in the update-draft-hips.yml workflow
- The regex pattern had incorrect backslash escaping that caused the JavaScript regex parser to fail
- Removed unnecessary escaping to make the regex valid

## Test plan
- [x] Tested regex pattern locally with various HIP file paths
- [ ] Verify workflow runs successfully after merge

The error was:
```
SyntaxError: Invalid regular expression flags
at /home/runner/_work/hiero-improvement-proposals/hiero-improvement-proposals/fetch-draft-hips.js:87
```