### PR TITLE
Clarify `hasScheduleCapacity()` boundary cases

### DIFF
--- a/HIP/hip-1215.md
+++ b/HIP/hip-1215.md
@@ -101,7 +101,11 @@ at address `0x00...abcd` by calling a "redirect" `deleteSchedule()` function at 
 ```
 
 The `hasScheduleCapacity()` returns `true` iff the given second still has capacity to
-schedule a contract call with the specified gas limit.
+schedule a contract call with the specified gas limit. It also returns `false` when the
+expiry second is invalid (either because it is not after current consensus time, or
+because it is too far in the future). The goal is to assure contract authors that when
+`hasScheduleCapacity(expiry, limit)` returns `true`, a subsequent valid call to
+`scheduleCall(to, expiry, limit, ...)` will _also_ succeed.
 
 The gas cost for scheduling variants will follow Hedera's standard system contract gas
 schedule, which is set based on the relative resource usage of the equivalent HAPI

--- a/HIP/hip-1215.md
+++ b/HIP/hip-1215.md
@@ -101,11 +101,11 @@ at address `0x00...abcd` by calling a "redirect" `deleteSchedule()` function at 
 ```
 
 The `hasScheduleCapacity()` returns `true` iff the given second still has capacity to
-schedule a contract call with the specified gas limit. It also returns `false` when the
-expiry second is invalid (either because it is not after current consensus time, or
-because it is too far in the future). The goal is to assure contract authors that when
-`hasScheduleCapacity(expiry, limit)` returns `true`, a subsequent valid call to
-`scheduleCall(to, expiry, limit, ...)` will _also_ succeed.
+schedule a contract call with the specified gas limit. It also returns `false` when either
+argument is invalid. For example, if expiry second is invalid because it is not after
+current consensus time, or because it is too far in the future). The goal is to assure
+contract authors that when `hasScheduleCapacity(expiry, limit)` returns `true`, a subsequent
+valid call to `scheduleCall(to, expiry, limit, ...)` will _also_ succeed.
 
 The gas cost for scheduling variants will follow Hedera's standard system contract gas
 schedule, which is set based on the relative resource usage of the equivalent HAPI


### PR DESCRIPTION
**Description**:
 - Updates HIP-1215 to clarify how `hasScheduleCapacity()` behaves given invalid parameters.