### PR TITLE
Fix EOF syntax error in draft HIPs workflow

### DIFF
--- a/.github/workflows/update-draft-hips.yml
+++ b/.github/workflows/update-draft-hips.yml
@@ -152,7 +152,6 @@ jobs:
             console.error('Failed to fetch and filter PRs:', error);
             process.exit(1);
           });
-          EOF
 
       - name: Run Script
         run: node fetch-draft-hips.js


### PR DESCRIPTION
Removes duplicate EOF that was causing ReferenceError in fetch-draft-hips.js script.