### PR TITLE
chore: Move `LambdaSStore` protobuf to HAPI section; move `PURE` type to rejected ideas

### DIFF
--- a/HIP/hip-1195.md
+++ b/HIP/hip-1195.md
@@ -19,11 +19,11 @@ updated: 2025-07-11
 
 We propose **hooks**, programmable Hiero extension points that let users customize the behavior of their entities.
 In principle, hooks could be programmed in any language, but we begin with **EVM hooks**. Users program EVM hooks by
-writing contracts in a language like Solidity that compiles to EVM bytecode. EVM hooks are either **pure** (using
-neither storage nor external contracts); or **lambdas** (like event-driven code running in the cloud, that may keep 
-state in a database to use state or call other external services). For any given entity, its user can create many hooks
-for that entity with different 64-bit **hook ids**. There is no limit on the number of hook ids than an entity can use;
-but its storage footprint, and hence rent, will increase proportionally.
+writing contracts in a language like Solidity that compiles to EVM bytecode. EVM hooks may have optimized variants in
+the future, but we propose first a full-featured **lambda** EVM hook. The name is chosen to evoke event-driven code
+running in the cloud or call other external services. For any given entity, its user can create many hooks for that
+entity with different 64-bit **hook ids**. There is no limit on the number of hook ids than an entity can use; bu
+tits storage footprint, and hence rent, will increase proportionally.
 
 As a first Hiero extension point, we propose **account allowance hooks**. Users can create these hooks on their
 accounts, and a Hiero API (HAPI) `CryptoTransfer` transaction can then reference an allowance hook just as it does an
@@ -77,10 +77,9 @@ hook,
 
 We propose the same gas price for EVM hook execution as for other contract operations. However, unlike contract calls,
 which are charged purely in gas, hook executions are already "gated" by the fee of their triggering transaction.
-So it makes sense to reduce the intrinsic gas cost of their execution. We propose adding two more properties to give
+So it makes sense to reduce the intrinsic gas cost of their execution. We propose adding another network property to give
 this effect while keeping it customizable for Hiero network operators.
 ```
-hooks.evm.pureIntrinsicGasCost=1000
 hooks.evm.lambdaIntrinsicGasCost=1000
 ```
 
@@ -195,12 +194,6 @@ Once again, we realize and affirm that programmatic entity extension introduces 
 themselves to hooks that the community has audited and adopted through application HIPs can then enjoy the full power of
 EVM programmability without incurring any special risk.
 
-#### Pure EVM hooks
-
-Pure EVM hooks execute in the same conceptual model, but in an extremely restricted mode. Not only is the initial EVM
-frame marked `static`, which prohibits all state-changing operations; but the network also disables the `PREVRANDAO`,
-`SLOAD`, and `CALL` opcodes. That is, a pure hook cannot do anything but apply a pure function to its input data.
-
 ### Mirror node and block explorer support
 
 Mirror nodes and block explorers will want to give at least summary data of an entity's hooks. For example, the Hedera
@@ -225,7 +218,7 @@ object with at least a subset of the information in the example below.
       /* Extension point this hook implements */
       "extension_point": "ACCOUNT_ALLOWANCE_HOOK",
 
-      /* PURE | LAMBDA */
+      /* LAMBDA */
       "type": "LAMBDA",
 
       /* Contract that contains the executing byte-code */
@@ -299,11 +292,6 @@ message HookCreationDetails {
    */
   oneof hook {
     /**
-     * A hook programmed in EVM bytecode that does not require access to state
-     * or interactions with external contracts.
-     */
-    PureEvmHook pure_evm_hook = 3;
-    /**
      * A hook programmed in EVM bytecode that may access state or interact with
      * external contracts.
      */
@@ -319,20 +307,10 @@ message HookCreationDetails {
 }
 ```
 
-The `PureEvmHook` and `LambdaEvmHook` messages share a common `EvmHookSpec` message that specifies the source of the
-hook's EVM bytecode. The `LambdaEvmHook` message also includes the initial storage slots for a lambda hook, if desired.
+The `LambdaEvmHook` uses a resuable a `EvmHookSpec` message that specifies the source of the hook's EVM
+bytecode. The `LambdaEvmHook` message also includes the initial storage slots for the lambda, if desired.
 
 ```protobuf
-/**
- * Definition of a pure EVM hook.
- */
-message PureEvmHook {
-  /**
-   * The specification for the hook.
-   */
-  EvmHookSpec spec = 1;
-}
-
 /**
  * Definition of a lambda EVM hook.
  */
@@ -430,13 +408,34 @@ message LambdaStorageSlot {
 }
 ```
 
+After an entity has a lambda, a new `LambdaSStore` transaction supports efficiently updating the lambda's storage. It
+must be signed by either the entity's controlling key or the admin key set in the lambda's `HookCreationDetails`.
+```protobuf
+/**
+ * Adds or removes key/value pairs in the storage of a lambda.
+ * <p>
+ * Either the lambda owner's key or the lambda's admin key must sign this transaction.
+ */
+message LambdaSStoreTransactionBody {
+  /**
+   * The id of the lambda whose storage is being updated.
+   */
+  CreatedHookId hook_id = 1;
+
+  /**
+   * The updates to the storage of the lambda.
+   */
+  repeated LambdaStorageUpdate storage_updates = 2;
+}
+```
+
 Once a hook is created for an entity, a transaction references the hook by its id relative to an implicit owner.
 Additional details for the hook's execution may be given as well; for example, EVM hook calls are specified by an
 `EvmHookCall` message that gives extra call data and gas limit.
 
 If the called hook does not match the provided specification, the network will fail the transaction with
-`BAD_HOOK_REQUEST`. If the relevant entity has no hook with the given id, the network will fail the transaction with
-`HOOK_NOT_FOUND`.
+`BAD_HOOK_REQUEST`. If the relevant entity has no hook with the given id, the network will fail the transaction
+with `HOOK_NOT_FOUND`.
 
 ```protobuf
 /**
@@ -627,13 +626,9 @@ message EvmHookState {
  */
 enum EvmHookType {
   /**
-   * A pure EVM hook.
-   */
-  PURE = 0;
-  /**
    * A lambda EVM hook.
    */
-  LAMBDA = 1;
+  LAMBDA = 0;
 }
 ```
 
@@ -655,27 +650,6 @@ message LambdaSlotKey {
    * The EVM key of this slot; may be left-padded with zeros to form a 256-bit word.
    */
   bytes key = 2;
-}
-```
-
-After an entity has a lambda, a new `LambdaSStore` transaction supports efficiently updating the lambda's storage. It
-must be signed by either the entity's controlling key or the admin key set in the lambda's `HookCreationDetails`.
-```protobuf
-/**
- * Adds or removes key/value pairs in the storage of a lambda.
- * <p>
- * Either the lambda owner's key or the lambda's admin key must sign this transaction.
- */
-message LambdaSStoreTransactionBody {
-  /**
-   * The id of the lambda whose storage is being updated.
-   */
-  CreatedHookId hook_id = 1;
-
-  /**
-   * The updates to the storage of the lambda.
-   */
-  repeated LambdaStorageUpdate storage_updates = 2;
 }
 ```
 
@@ -1027,8 +1001,8 @@ unlocking entire new classes of applications that would be impractical to build 
 #### Receiver signature waiver for HTS assets without custom fees
 
 In this example we have our own account `0.0.U` with `receiver_sig_required=true`, and want to carve out an exception
-for exactly HTS token credits to our account with no assessed custom fees. We create a pure EVM hook with id `2`
-whose referenced contract is as follows,
+for exactly HTS token credits to our account with no assessed custom fees. We create an EVM hook with id `2` whose
+referenced contract is as follows,
 
 ```solidity
 import "./IHederaTokenService.sol";
@@ -1119,6 +1093,13 @@ In progress, please see [here](https://github.com/hiero-ledger/hiero-consensus-n
    Ultimately it seemed better to keep the charging scheme simple and let hooks manage any refunds themselves.
 5. We considered not including the `IHieroAccountAllowancePrePostHook` option, but this left a gap in support for the
    full range of HTS/ERC-20 integrations that Hedera users will likely be interested in.
+6. We considered **pure** EVM hooks with the same conceptual model as lambdas, but with some severe restrictions. The
+   initial EVM frame would be marked `static`, which prohibits all state-changing operations; and we would also disable
+   the `PREVRANDAO`, `SLOAD`, and `CALL` opcodes. Such a hook could not do anything but apply a pure function to its
+   input data; hence pure hook calls could be computed asynchronously, and the results used immediately at consensus.
+   But in light of upcoming general approaches to optimistic concurrent transaction handling, the value of pure hooks
+   did not seem worth the added complexity. Nonetheless, the protobufs here are designed to let us add such EVM
+   specializations in the future if the calculus changes.
 
 ## Open Issues
 


### PR DESCRIPTION
**Description**:
 - Fixes section location of `LambdaSStore` protobuf message.
 - Given upcoming general approaches to optimistic concurrent transaction-handling, delays a `PureEvmHook` type to future work.