### PR TITLE
Update HIP 1215

### DIFF
--- a/HIP/hip-1215.md
+++ b/HIP/hip-1215.md
@@ -14,7 +14,7 @@ status: Last Call
 last-call-date-time: 2025-07-14T07:00:00Z
 created: 2025-04-09
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/1096
-updated: 2025-07-23
+updated: 2025-09-25
 requires: 756
 replaces: 
 superseded-by: 
@@ -32,7 +32,7 @@ acceptable second (if one exists) with an affordable gas budget.
 ## Motivation
 HIP-755 ("Schedule Service System Contract") extended the ability to schedule transactions
 to the Hedera Smart Contract Service. While this is very useful for smart contract calls by
-externally owned accounts (EOAs), it requires off-chain coordination and it does not extend
+externally owned accounts (EOAs), it requires off-chain coordination, and it does not extend
 to smart contracts calling other smart contracts as the origin of the transaction. 
 Furthermore, HIP-755 does not fully support regularly scheduled transactions, as the 
 off-chain signatures and message submission must be repeated for each transaction.
@@ -43,7 +43,7 @@ contract calls can be made at regularly scheduled intervals as long as the trans
 payer has enough HBAR to cover the scheduling and gas and fees.
 
 ## Rationale
-This HIP provides the possiblility to have fully on-chain "cron jobs" that regularly
+This HIP provides the possibility to have fully on-chain "cron jobs" that regularly
 call smart contracts, replacing various off-chain mechanisms users have relied on til now.
 
 ## User stories
@@ -61,10 +61,10 @@ needed to schedule an arbitrary call from within the EVM, including the `to` add
 the call data to use, the gas limit for the future call, and the value to send with
 that call.
 
-An important option is to let the scheduling contract specify a sender address that
+An important option is to let the scheduling contract specify a payer address that
 may be different from its own. In this case the scheduled call can only execute 
-after receiving enough valid signatures to activate the sender's key. The difference
-between `scheduleCallWithSender()` and `executeCallOnSenderSignature()` is that the
+after receiving enough valid signatures to activate the payer's key. The difference
+between `scheduleCallWithPayer()` and `executeCallOnPayerSignature()` is that the
 former still waits until the consensus second is not before `expirySecond` to execute, while
 the latter executes as soon as the payer signs (unless consensus time is already 
 past the `expirySecond`, of course).
@@ -74,8 +74,8 @@ past the `expirySecond`, of course).
 | Hash        | Function signature                                                                                                                                             |
 |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 0x6f5bfde8  | scheduleCall(address to, uint256 expirySecond, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64, address)                                 |
-| 0xeb459436  | scheduleCallWithSender(address to, address sender, uint256 expirySecond, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64, address)       |
-| 0x2c300715  | executeCallOnSenderSignature(address to, address sender, uint256 expirySecond, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64, address) |
+| 0xe6599c18  | scheduleCallWithPayer(address to, address payer, uint256 expirySecond, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64, address)       |
+| 0x105772b2  | executeCallOnPayerSignature(address to, address payer, uint256 expirySecond, uint256 gasLimit, uint64 value, bytes memory callData) returns (int64, address) |
 | 0x72d42394  | deleteSchedule(address scheduleAddress) returns (int64)                                                                                                        |
 | 0xdfb4a999  | hasScheduleCapacity(uint256 expirySecond, uint256 gasLimit) view returns (bool)                                                                                |
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ schedule and an `int64` that is the protobuf ordinal of enum value `"SCHEDULE_EX
 If the `scheduleCall()` variants succeed, they return the address of the newly created
 scheduled transaction and `22` as the status code of `SUCCESS`. A contract may attempt to
 delete an already scheduled transaction with the `deleteSchedule(address)`, receiving `22`
-iff the delete succeeds. A contract or EOA may also attempt to delete a scheduled transaction
+iff delete succeeds. A contract or EOA may also attempt to delete a scheduled transaction
 at address `0x00...abcd` by calling a "redirect" `deleteSchedule()` function at that address.
 ```
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -176,7 +176,10 @@ developers roll their own.
 
 ## Open Issues
 
-There are no known open issues.
+- Scheduling a Contract Create transaction is out of the scope of this HIP. Providing a zero `to` address parameter 
+ for the `scheduleCall()`, `scheduleCallWithPayer()` and `executeCallOnPayerSignature()` functions is considered invalid
+ and will result in failure with `INVALID_TRANSACTION_BODY` response code.
+ Additionally, the ability to schedule contract creation could be introduced with a future HIP or an extension to this one.
 
 ## References
 1. [HIP-755](https://hips.hedera.com/hip/hip-755)


### PR DESCRIPTION
Updating the HIP-1215 smart contract function selectors.

We want to provide more clarity to the users thus we change the `sender` wording to `payer`.
Also introduced is an item to the `Open Issues` section regarding an unsupported case for contract deployment.