### PR TITLE
HIP-1446: Multiple other-parents

### DIFF
--- a/HIP/hip-1399.md
+++ b/HIP/hip-1399.md
@@ -11,7 +11,7 @@ needs-hiero-approval: Yes
 needs-hedera-review: Yes
 status: Draft
 created: 2026-04-02
-updated: 2026-04-02
+updated: 2026-06-02
 ---
 
 ## Abstract
@@ -53,25 +53,6 @@ consensus with fewer events provides several benefits:
   between nodes and transmitted to downstream consumers.
 
 ## Rationale
-
-### Why multiple other-parents rather than alternative approaches
-
-Several approaches could improve consensus speed:
-
-1. **Increasing gossip frequency** — Nodes could gossip more often, but this increases
-   network traffic without improving the information density per event.
-
-2. **Larger batches of transactions per event** — This improves throughput but does not
-   address the fundamental propagation delay of peer state information.
-
-3. **Multiple other-parents per event** — This directly addresses the propagation bottleneck
-   by allowing each event to capture state from multiple peers simultaneously. Each event
-   becomes a richer source of information for the consensus algorithm, leading to faster
-   convergence.
-
-Option 3 was chosen because it targets the core limitation — information propagation rate
-through the hashgraph — without requiring changes to the gossip protocol itself or increasing
-network traffic proportionally.
 
 ### Configurable maximum
 
@@ -129,7 +110,7 @@ A new configuration parameter controls the maximum number of other-parents per e
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `maxOtherParents` | integer | 1 | Maximum number of other-parents an event may reference. Must be >= 1. |
+| `event.creation.maxOtherParents` | integer | 1 | Maximum number of other-parents an event may reference. Must be >= 1. |
 
 Setting `maxOtherParents` to 1 preserves the current single other-parent behavior, ensuring
 full backward compatibility.
@@ -179,10 +160,6 @@ This change is backward compatible. Setting `maxOtherParents` to 1 produces iden
 behavior to the current algorithm. The change does not modify any protobuf definitions,
 public APIs, or external interfaces.
 
-During a network upgrade, all nodes must be updated to the version that supports multiple
-other-parents before the `maxOtherParents` parameter is increased above 1. Nodes running
-older software would reject events with multiple other-parents as invalid.
-
 ## Security Implications
 
 The Byzantine fault tolerance guarantees of the hashgraph algorithm are maintained. The
@@ -214,22 +191,6 @@ For developers working on the consensus node:
 
 The reference implementation is available in the
 [hiero-consensus-node](https://github.com/hiero-ledger/hiero-consensus-node) repository.
-
-## Rejected Ideas
-
-### Fixed number of other-parents
-
-A fixed number (e.g., always exactly 2 other-parents) was considered but rejected in favor
-of a configurable maximum. A fixed number would not allow the network to adapt to different
-conditions and would force events to include other-parents even when fewer are available
-(e.g., during network startup or when peers are temporarily unreachable).
-
-### Unlimited other-parents
-
-Allowing an unlimited number of other-parents was considered but rejected because it could
-lead to excessively large events and increased validation overhead without proportional
-benefit. Beyond a certain point, additional other-parents provide diminishing returns for
-consensus speed.
 
 ## Open Issues
 

--- a/HIP/hip-1399.md
+++ b/HIP/hip-1399.md
@@ -1,0 +1,249 @@
+---
+hip: 1399
+title: Multiple Other-Parents in Hashgraph Events
+author: Lazar Petrović (@lpetrovic05)
+working-group: Lazar Petrović (@lpetrovic05)
+requested-by: Hashgraph
+discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1399
+type: Standards Track
+category: Core
+needs-hiero-approval: Yes
+needs-hedera-review: Yes
+status: Draft
+created: 2026-04-02
+updated: 2026-04-02
+---
+
+## Abstract
+
+This HIP proposes extending the Hiero hashgraph consensus algorithm to allow events to
+reference multiple other-parents instead of being limited to a single other-parent. In the
+current algorithm, each event in the hashgraph has exactly one self-parent (created by the
+same node) and at most one other-parent (created by a different node). This proposal lifts
+the single other-parent restriction, allowing an event to reference a configurable number of
+other-parents. By doing so, each event carries information from multiple peers
+simultaneously, enabling the network to reach consensus with fewer events overall.
+
+## Motivation
+
+The hashgraph consensus algorithm achieves consensus by propagating information through
+events in the hashgraph. Each time a node creates an event, it records what it knows —
+including the latest state of the node it communicated with via the other-parent link.
+
+With a single other-parent, each event can only incorporate information from one peer. This
+means that information from the rest of the network must propagate through a chain of
+successive events before a node becomes aware of it. In networks with many nodes, this
+sequential propagation creates a bottleneck: more rounds of gossip are needed before
+sufficient information has spread for the algorithm to reach consensus.
+
+By allowing multiple other-parents per event, a single event can incorporate information
+from several peers at once. This increases the rate at which information propagates through
+the hashgraph, allowing the network to reach consensus with fewer total events. Reaching
+consensus with fewer events provides several benefits:
+
+- **Faster consensus**: Fewer rounds of event creation are needed before consensus is
+  reached, reducing transaction finality time.
+- **Reduced processing cost**: Every event has a computational cost — its signature must be
+  verified, its parents must be validated, and it must be processed by the consensus
+  algorithm. Fewer events means less processing overhead per round of consensus.
+- **Smaller block stream**: Events are stored permanently in the block stream. Reaching
+  consensus with fewer events reduces the long-term storage footprint of the network,
+  lowering costs for block nodes, mirror nodes, and anyone archiving the block stream.
+- **Lower bandwidth consumption**: Fewer events means less data that must be gossiped
+  between nodes and transmitted to downstream consumers.
+
+## Rationale
+
+### Why multiple other-parents rather than alternative approaches
+
+Several approaches could improve consensus speed:
+
+1. **Increasing gossip frequency** — Nodes could gossip more often, but this increases
+   network traffic without improving the information density per event.
+
+2. **Larger batches of transactions per event** — This improves throughput but does not
+   address the fundamental propagation delay of peer state information.
+
+3. **Multiple other-parents per event** — This directly addresses the propagation bottleneck
+   by allowing each event to capture state from multiple peers simultaneously. Each event
+   becomes a richer source of information for the consensus algorithm, leading to faster
+   convergence.
+
+Option 3 was chosen because it targets the core limitation — information propagation rate
+through the hashgraph — without requiring changes to the gossip protocol itself or increasing
+network traffic proportionally.
+
+### Configurable maximum
+
+The maximum number of other-parents is made configurable rather than fixed to allow the
+network to tune this parameter based on operational conditions. A higher limit increases
+information density per event but also increases event size and validation complexity. Making
+it configurable allows operators to find the optimal balance for their network topology and
+workload.
+
+### Internal-only change
+
+This change is internal to the consensus algorithm. The existing protobuf definitions for
+events already support referencing parent events by hash. The change extends the internal
+event creation and validation logic to handle multiple other-parent references. No changes
+to public-facing APIs or protobuf message definitions are required.
+
+## User stories
+
+> As a network operator, I want consensus to converge faster so that transaction finality
+> times are reduced for end users.
+
+> As a dApp developer, I want lower consensus latency so that my application can provide a
+> more responsive user experience.
+
+> As a network administrator, I want to configure the maximum number of other-parents so
+> that I can tune consensus performance based on network conditions.
+
+## Specification
+
+### Overview
+
+Currently, when a node creates a new event, it sets:
+- **Self-parent**: The most recent event created by the same node.
+- **Other-parent**: The most recent event known from the peer the node last synced with.
+
+This proposal extends event creation so that a node may set:
+- **Self-parent**: The most recent event created by the same node (unchanged).
+- **Other-parents**: The most recent events known from up to _N_ peers, where _N_ is a
+  configurable maximum.
+
+### Event creation
+
+When a node creates a new event, it selects other-parents as follows:
+
+1. The node maintains a record of the latest event it has received from each peer.
+2. When creating a new event, the node selects up to _N_ peers from which it has received
+   events that have not yet been referenced as other-parents in the node's prior events.
+3. The selected events become the other-parents of the new event.
+
+The self-parent remains the node's own most recent event, as in the current algorithm.
+
+### Configuration
+
+A new configuration parameter controls the maximum number of other-parents per event:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `maxOtherParents` | integer | 1 | Maximum number of other-parents an event may reference. Must be >= 1. |
+
+Setting `maxOtherParents` to 1 preserves the current single other-parent behavior, ensuring
+full backward compatibility.
+
+### Consensus algorithm impact
+
+The core hashgraph consensus algorithm (determining famous witnesses, computing rounds,
+finding order through voting) operates on the hashgraph structure through ancestor relationships.
+The definition of "ancestor" and "strongly seeing" naturally extends to events with multiple
+other-parents:
+
+- **Ancestor**: Event _X_ is an ancestor of event _Y_ if there is a directed path from _Y_
+  to _X_ through parent links (self-parent or any other-parent).
+- **Strongly seeing**: Event _Y_ strongly sees event _X_ if _Y_ can see _X_ through paths
+  that pass through events created by more than 2/3 of the network's stake weight. With
+  multiple other-parents, these paths are established more quickly.
+
+The fundamental consensus guarantees (Byzantine fault tolerance for up to 1/3 of stake
+weight, fairness, and finality) are preserved because they depend on the hashgraph's connectivity
+properties, which are only strengthened by additional parent links.
+
+### Validation
+
+When a node receives an event with multiple other-parents, it validates:
+
+1. The number of other-parents does not exceed `maxOtherParents`.
+2. Each other-parent references a valid, known event.
+3. No two other-parents reference events created by the same node.
+4. The self-parent is distinct from all other-parents.
+
+Events that fail validation are rejected.
+
+### Impact on Mirror Node
+
+No impact. This change is internal to the consensus algorithm. Mirror nodes consume
+transactions and their results, which are unaffected by the number of other-parents in
+consensus events.
+
+### Impact on SDK
+
+No impact. The SDKs interact with the network through transactions and queries, which are
+not affected by internal consensus event structure.
+
+## Backwards Compatibility
+
+This change is backward compatible. Setting `maxOtherParents` to 1 produces identical
+behavior to the current algorithm. The change does not modify any protobuf definitions,
+public APIs, or external interfaces.
+
+During a network upgrade, all nodes must be updated to the version that supports multiple
+other-parents before the `maxOtherParents` parameter is increased above 1. Nodes running
+older software would reject events with multiple other-parents as invalid.
+
+## Security Implications
+
+The Byzantine fault tolerance guarantees of the hashgraph algorithm are maintained. The
+algorithm's security relies on the properties of the hashgraph and the assumption that no more
+than 1/3 of stake weight is controlled by malicious actors. Adding more parent links to
+events strengthens the hashgraph's connectivity, which does not weaken these guarantees.
+
+A potential concern is that a malicious node could attempt to create events referencing
+an excessive number of other-parents to increase event sizes. The configurable
+`maxOtherParents` limit mitigates this by capping the number of other-parents, and the
+validation rules ensure events exceeding this limit are rejected.
+
+## How to Teach This
+
+The key conceptual change is straightforward: previously, each event had one "link" to
+another node's event; now it can have multiple such links.
+
+An analogy: imagine a group of people sharing news by phone. Previously, each person could
+only relay news from one other person per call. Now, each person can relay news from several
+people at once, so everyone learns the full picture faster.
+
+For developers working on the consensus node:
+- Event creation logic now selects multiple peers instead of one.
+- Ancestor traversal and "strongly seeing" computations follow all parent links, not just
+  two.
+- The `maxOtherParents` configuration parameter controls the behavior.
+
+## Reference Implementation
+
+The reference implementation is available in the
+[hiero-consensus-node](https://github.com/hiero-ledger/hiero-consensus-node) repository.
+
+## Rejected Ideas
+
+### Fixed number of other-parents
+
+A fixed number (e.g., always exactly 2 other-parents) was considered but rejected in favor
+of a configurable maximum. A fixed number would not allow the network to adapt to different
+conditions and would force events to include other-parents even when fewer are available
+(e.g., during network startup or when peers are temporarily unreachable).
+
+### Unlimited other-parents
+
+Allowing an unlimited number of other-parents was considered but rejected because it could
+lead to excessively large events and increased validation overhead without proportional
+benefit. Beyond a certain point, additional other-parents provide diminishing returns for
+consensus speed.
+
+## Open Issues
+
+- Determining the optimal default value for `maxOtherParents` based on empirical testing
+  across different network sizes.
+- Evaluating the impact of different `maxOtherParents` values on network bandwidth
+  consumption and event processing throughput.
+
+## References
+
+- [Hashgraph Consensus Algorithm](https://www.swirlds.com/downloads/SWIRLDS-TR-2016-01.pdf)
+- [Hiero Consensus Node](https://github.com/hiero-ledger/hiero-consensus-node)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 —
+see [LICENSE](../LICENSE) or <https://www.apache.org/licenses/LICENSE-2.0>.

--- a/HIP/hip-1446.md
+++ b/HIP/hip-1446.md
@@ -1,10 +1,10 @@
 ---
-hip: 1399
+hip: 1446
 title: Multiple Other-Parents in Hashgraph Events
 author: Lazar Petrović (@lpetrovic05)
 working-group: Lazar Petrović (@lpetrovic05)
 requested-by: Hashgraph
-discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1399
+discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1446
 type: Standards Track
 category: Core
 needs-hiero-approval: Yes

--- a/HIP/hip-1446.md
+++ b/HIP/hip-1446.md
@@ -9,7 +9,7 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Last Call
+status: Approved
 last-call-date-time: 2026-05-20T07:00:00Z
 created: 2026-04-02
 updated: 2026-05-06

--- a/HIP/hip-1446.md
+++ b/HIP/hip-1446.md
@@ -116,6 +116,11 @@ A new configuration parameter controls the maximum number of other-parents per e
 Setting `maxOtherParents` to 1 preserves the current single other-parent behavior, ensuring
 full backward compatibility.
 
+### Metrics
+
+A metric is added to monitor the number of parents per event, called `avgNumParents`.
+
+
 ### Consensus algorithm impact
 
 The core hashgraph consensus algorithm (determining famous witnesses, computing rounds,
@@ -149,6 +154,12 @@ Events that fail validation are rejected.
 No impact. This change is internal to the consensus algorithm. Mirror nodes consume
 transactions and their results, which are unaffected by the number of other-parents in
 consensus events.
+
+### Impact on Block Nodes
+
+This change will likely reduce the block size. While the event size may increase due to it storing more parent 
+references, the total number of events needed to reach consensus will decrease. This results in fewer events being 
+stored in the block stream, leading to smaller block sizes and reduced storage requirements for block nodes.
 
 ### Impact on SDK
 

--- a/HIP/hip-1446.md
+++ b/HIP/hip-1446.md
@@ -9,9 +9,10 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Draft
+status: Last Call
+last-call-date-time: 2026-05-20T07:00:00Z
 created: 2026-04-02
-updated: 2026-06-02
+updated: 2026-05-06
 ---
 
 ## Abstract


### PR DESCRIPTION
**Description**:

This HIP proposes extending the Hiero hashgraph consensus algorithm to allow events to
reference multiple other-parents instead of being limited to a single other-parent.
