### PR TITLE
HIP-1448 Broadcast mechanism for gossip

### DIFF
--- a/HIP/hip-1448.md
+++ b/HIP/hip-1448.md
@@ -8,9 +8,10 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Review
+status: Last Call
+last-call-date-time: 2026-05-20T07:00:00Z
 created: 2025-10-01
-updated: 2026-04-07
+updated: 2026-05-13
 release:
 ---
 

--- a/HIP/hip-1448.md
+++ b/HIP/hip-1448.md
@@ -1,0 +1,230 @@
+---
+hip: 1448
+title: Simple Event Broadcast
+author: Artur Biesiadowski (@abies)
+working-group: Artur Biesiadowski (@abies)
+discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1448
+type: Standards Track
+category: Core
+needs-hiero-approval: Yes
+needs-hedera-review: Yes
+status: Draft
+created: 2025-10-01
+updated: 2026-04-07
+release:
+---
+
+## Abstract
+
+This HIP introduces a broadcast mechanism for event propagation in the Hiero
+consensus network. When a node creates a new self-event, it immediately sends
+that event directly to all connected peer nodes (neighbours), without waiting
+for the next gossip sync cycle. This reduces event propagation latency to
+approximately half a ping round-trip in normal network conditions.
+
+The existing gossip synchronization protocol continues to run as a reliability
+fallback, ensuring events eventually reach all nodes even under degraded network
+conditions. Broadcast is strictly additive — it does not replace gossip sync.
+
+## Motivation
+
+The current gossip sync protocol requires multiple round-trips to exchange
+events: nodes must exchange tipsets and event windows, confirm tipset
+visibility, and only then transfer events. During a sync, the set of events
+to be sent is fixed — no new events propagate until the next sync cycle begins.
+
+This multi-round-trip design is appropriate for reliability but introduces
+unnecessary latency in normal operating conditions where the network is healthy.
+
+With broadcast, each self-event is sent immediately upon creation. In the common
+case (no network disruption), the receiving node has the event in approximately
+half a ping round-trip, rather than waiting for the next sync cycle to begin.
+
+**Measured impact:**
+
+For super-low latency networks, C2C latency decreases by factor of 2x to 3x.
+For high-latency networks (similar to mainnet), we observer modest decrease in C2C latency,
+in the range of 15-20%. At the same time, event duplicate rate decreases dramatically, leading to around 3x
+reduction in I/O bandwith.
+
+
+## Rationale
+
+Broadcast is implemented as the least disruptive possible mechanism:
+
+- Events are sent over the existing gossip connection — no new ports or
+  connections are required between nodes.
+- Broadcast messages are interleaved with normal sync communication on the
+  same channel.
+- No confirmation or deduplication logic is required on the sender side — each
+  node simply sends its self-events to all neighbours as soon as they are
+  created. Duplicate handling is already present in the event intake pipeline.
+
+There is one exception: if a peer is significantly behind in event processing
+or in the middle of a disconnect, broadcast events are suppressed for that peer
+to avoid wasting bandwidth on an already-overloaded node. The conditions for
+this suppression are configurable, but can be triggered based on unprocessed
+message queue depth or the measured message response time between the nodes.
+
+## Specification
+
+The RPC sync protocol is extended with a new message type `BROADCAST_EVENT`,
+assigned message ID 7. A serialized `GossipMessage` in PBJ format follows
+immediately after the message ID. This reuses the existing `GossipEvent`
+protobuf structure.
+
+By introducing a separate message ID (rather than reusing `EVENT`), the
+implementation can:
+
+- Send broadcast events regardless of the current sync stage
+- Bypass the intake counter gate that prevents a new sync from starting until
+  the last event of the previous sync is fully processed
+- Allow independent evolution of the broadcast and sync event streams (e.g.,
+  future batching or compression on the sync stream would not affect broadcast)
+
+### Which nodes broadcast
+
+All nodes broadcast their self-events. Each node sends every self-event it
+creates to all of its currently connected neighbours immediately upon creation,
+subject to the peer suppression condition described above.
+
+### Configuration
+
+Broadcast is enabled by default. It can be disabled via the configuration
+property `broadcast.broadcastEnabled`. Restart is required to apply the change.
+
+### Protobuf
+
+Protobuf definitions are NOT changed by this HIP and included here just for reference.
+
+
+```protobuf
+/**
+ * An event that is sent and received via gossip.
+ */
+message GossipEvent {
+  /**
+   * The core event data.
+   */
+  EventCore event_core = 1;
+
+  /**
+   * A node signature on the event hash.
+   * The signature SHALL be created with the SHA384withRSA algorithm.
+   * The signature MUST verify using the public key belonging to the
+   * event_creator. The event_creator public key SHALL be read from the
+   * address book that corresponds to the event's birth round.
+   */
+  bytes signature = 2;
+
+  /**
+   * A list of serialized transactions.
+   * This field MAY contain zero transactions.
+   * Each transaction SHALL be presented exactly as supplied to the
+   * consensus algorithm.
+   */
+  repeated bytes transactions = 4;
+
+  /**
+   * A list of EventDescriptors representing the parents of this event.
+   * The list SHALL include zero or one self parents, and zero or more
+   * other parents. The first element SHALL be the self parent, if one
+   * exists. The list SHALL NOT include more than one parent from the
+   * same creator.
+   */
+  repeated EventDescriptor parents = 5;
+}
+
+message EventCore {
+  int64 creator_node_id = 1;
+  int64 birth_round = 2;
+  proto.Timestamp time_created = 3;
+  int64 coin = 5;
+}
+
+message EventDescriptor {
+  bytes hash = 1;
+  int64 creator_node_id = 2;
+  int64 birth_round = 3;
+}
+```
+
+### Impact on Mirror Node
+
+No impact. Mirror Node does not interact with the gossip protocol directly.
+
+### Impact on SDK
+
+No impact. This is an internal node-to-node protocol change.
+
+### Impact on Block Node
+
+No impact. Block Nodes receive block streams, not gossip events. The broadcast
+mechanism does not affect the block stream interface.
+
+### Impact on Network Operators
+
+No operational changes are required. Broadcast operates on the existing gossip
+port and connection. No firewall rule changes or certificate updates are needed.
+Operators may observe a reduction in average event propagation latency.
+
+
+## Backwards Compatibility
+
+This feature is NOT backward compatible. The gossip protocol currently has no
+support for backward or forward compatibility between versions — all nodes must
+be updated simultaneously. Nodes running different versions will not connect,
+due to the existing version enforcement in the network handshake (this is
+independent of this HIP).
+
+There are no compatibility concerns with external interfaces — SDKs, event
+scrapers, Mirror Node, and Block Node are unaffected.
+
+## Security Implications
+
+No new security implications are introduced. The broadcast connection is already
+established and authenticated for gossip purposes. Events sent via broadcast are
+serialized, signed, and verified in exactly the same manner as events received
+through the sync protocol. No new authentication surface is created.
+
+## Reference Implementation
+
+PR [#20348](https://github.com/hiero-ledger/hiero-consensus-node/pull/20348)
+
+## Rejected Ideas
+
+**Separate broadcast channel on the same port**
+Rejected. The current gossip implementation enforces a single connection between
+any pair of nodes, immediately disconnecting any previous connection when a new
+one is established. Supporting a second channel on the same port would require
+special-casing this logic throughout the connection management code.
+
+**Separate broadcast channel on a different port**
+Rejected. This would require opening firewall rules between every pair of nodes,
+which is operationally impractical in high-security mainnet environments.
+
+**Reusing the gRPC port**
+Rejected. The gRPC port serves user-facing endpoints with different
+authentication requirements. Mixing internal gossip methods with user-facing
+APIs on the same port introduces security risk. Additionally, the gRPC layer is
+architecturally distant from gossip internals, and broadcast events need to
+interoperate closely with gossip state.
+
+*Longer-term consideration:* Migrating the entire gossip protocol to gRPC on
+the existing gossip port is worth exploring in a future HIP, once the Reconnect
+protocol is updated to use Block Node. That change is out of scope here.
+
+## Open Issues
+
+1. **Peer suppression thresholds** — The conditions under which broadcast is
+   suppressed for an overloaded peer need to be precisely defined (measurable
+   thresholds for queue depth or connection state).
+
+## References
+
+- Reference implementation: [PR #20348](https://github.com/hiero-ledger/hiero-consensus-node/pull/20348)
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 —
+see [LICENSE](../LICENSE) or <https://www.apache.org/licenses/LICENSE-2.0>.

--- a/HIP/hip-1448.md
+++ b/HIP/hip-1448.md
@@ -8,7 +8,7 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Last Call
+status: Approved
 last-call-date-time: 2026-05-20T07:00:00Z
 created: 2025-10-01
 updated: 2026-05-13

--- a/HIP/hip-1448.md
+++ b/HIP/hip-1448.md
@@ -8,7 +8,7 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Draft
+status: Review
 created: 2025-10-01
 updated: 2026-04-07
 release:

--- a/HIP/hip-1448.md
+++ b/HIP/hip-1448.md
@@ -42,10 +42,13 @@ half a ping round-trip, rather than waiting for the next sync cycle to begin.
 
 **Measured impact:**
 
-For super-low latency networks, C2C latency decreases by factor of 2x to 3x.
-For high-latency networks (similar to mainnet), we observer modest decrease in C2C latency,
-in the range of 15-20%. At the same time, event duplicate rate decreases dramatically, leading to around 3x
-reduction in I/O bandwith.
+For super-low latency networks, with fine-tuned event creation periods, C2C latency decreases very visibly. 
+Test measurements have shown decrease from 10ms to 4ms range for consensus time, also reducing event 
+duplicate ratio to almost zero.
+
+For high-latency testing network (similar to the mainnet), we observe modest decrease in C2C latency, 
+in the range of 15-20% (from 2.9s to 2.4s). At the same time, event duplicate rate decreases dramatically, 
+leading to around 3x reduction in I/O bandwith (from 60-80% average, to 0-20% average).
 
 
 ## Rationale
@@ -92,6 +95,26 @@ subject to the peer suppression condition described above.
 
 Broadcast is enabled by default. It can be disabled via the configuration
 property `broadcast.broadcastEnabled`. Restart is required to apply the change.
+
+### Maintainability 
+
+Some extra metrics are added to increase visibility into broadcast function, plus some existing metrics are affected.
+
+`platform.broadcastEventsSent` is a new metrics which shows how many events per second are eligible for broadcast; 
+this should be a number similar to number of self-created events. Each event is counted once, regardless to how many 
+peers it is sent.
+
+`platform.broadcastEventsReceived` is a new metric which shows how many events per second are received by broadcast 
+mechanism; this number should be similar to total number of events per second in entire network minus number of 
+self-created events. In case broadcast is disabled between some nodes with due heuristics, it might be lower than that.
+
+Both these metrics will be zero if broadcast is disabled in configuration and are fastest way to check that deployment
+of broadcast was sucessful.
+
+`platform.dupEvPercent` is an existing metric, which shows biggest difference when broadcast is enabled. In the case
+broadcast is running perfectly, it should be very low, as sync process should be transferring almost no events and
+broadcast itself by definition has zero duplicate rate (as every peer is sending only its own events).
+
 
 ### Protobuf
 
@@ -219,6 +242,9 @@ protocol is updated to use Block Node. That change is out of scope here.
 1. **Peer suppression thresholds** — The conditions under which broadcast is
    suppressed for an overloaded peer need to be precisely defined (measurable
    thresholds for queue depth or connection state).
+2. It is not fully clear why experiments in the high-latency networks see considerably lower benefit 
+   from enabling broadcast compared to the low-latency networks. More investigation is needs, but in both cases,
+   benefits are visible and well beyond measurement errors.
 
 ## References
 


### PR DESCRIPTION
**Description**:

This HIP introduces a broadcast mechanism for event propagation in the Hiero
consensus network. When a node creates a new self-event, it immediately sends
that event directly to all connected peer nodes (neighbours), without waiting
for the next gossip sync cycle.