### PR TITLE
Finalize HIP-1215: Generalized Scheduled Contract Calls (v0.68.0)

### DIFF
--- a/HIP/hip-1215.md
+++ b/HIP/hip-1215.md
@@ -10,11 +10,12 @@ needs-hiero-approval: Yes
 needs-hedera-review: Yes
 hedera-review-date:
 hedera-acceptance-decision:
-status: Approved
+status: Final
+release: v0.68.0
 last-call-date-time: 2025-07-14T07:00:00Z
 created: 2025-06-10
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/1096
-updated: 2025-09-25
+updated: 2026-04-19
 requires: 756
 replaces: 
 superseded-by: 


### PR DESCRIPTION
## Summary

- Marks HIP-1215 as `Final`
- Adds `release: v0.68.0` — shipped to Hedera mainnet on 2025-12-18
- Updates `updated` date to 2026-04-19

## Reference

- [v0.68 release notes](https://docs.hedera.com/hedera/networks/release-notes/services)