### PR TITLE
Finalize HIP-1259: Fee Collection Account (v0.70.0)

### DIFF
--- a/HIP/hip-1259.md
+++ b/HIP/hip-1259.md
@@ -7,13 +7,15 @@ requested-by: Hashgraph
 type: Standards Track
 category: Core
 needs-hiero-approval: Yes
-status: Approved
+status: Final
+release: v0.70.0
 needs-hedera-review: Yes
 hedera-review-date: 2025-08-19
 hedera-acceptance-decision: Accepted
 created: 2025-07-11
 last-call-date-time: 2025-08-12
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1259
+updated: 2026-04-19
 ---
 
 # Abstract


### PR DESCRIPTION
## Summary

- Marks HIP-1259 as `Final`
- Adds `release: v0.70.0` — shipped to Hedera mainnet on 2026-02-11
- Adds `updated` date 2026-04-19

## Reference

- [v0.70 release notes](https://docs.hedera.com/hedera/networks/release-notes/services)