### PR TITLE
Finalize HIP-1299: Node Account ID Refinements for Dynamic Address Book (v0.69.0)

### DIFF
--- a/HIP/hip-1299.md
+++ b/HIP/hip-1299.md
@@ -8,10 +8,11 @@ needs-hiero-approval: Yes
 needs-hedera-review: Yes
 hedera-review-date: 2025-10-21
 hedera-acceptance-decision: Accepted
-status: Approved
+status: Final
+release: v0.69.0
 last-call-date-time: 2025-10-27T07:00:00Z
 created: 2025-09-29
-updated: 2025-11-04
+updated: 2026-04-19
 requires: 869
 ---
 


### PR DESCRIPTION
## Summary

- Marks HIP-1299 as `Final`
- Adds `release: v0.69.0` — final phase shipped to Hedera mainnet on 2026-01-21
- Updates `updated` date to 2026-04-19

## Reference

- [v0.69 release notes](https://docs.hedera.com/hedera/networks/release-notes/services)