### PR TITLE
Move HIP-1342 to Last Call

### DIFF
--- a/HIP/hip-1342.md
+++ b/HIP/hip-1342.md
@@ -9,9 +9,10 @@ type: Standards Track
 category: Service
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Review
+status: Last Call
+last-call-date-time: 2026-05-20T07:00:00Z
 created: 2025-11-14
-updated: 2026-02-02
+updated: 2026-05-06
 release:
 ---
 


### PR DESCRIPTION
**Description**

Bumps HIP-1342 (Ignore Trailing Calldata for System Contracts) frontmatter from \`status: Review\` to \`status: Last Call\` and adds \`last-call-date-time: 2026-05-20T07:00:00Z\` (14-day Last Call window).

This aligns the HIP file on \`main\` with the tracker board, which has shown HIP-1342 in Last Call for several weeks.

**Related issue(s)**: n/a

**Checklist**
- [x] Frontmatter updated
- [ ] Reviewed by HIP maintainers