### PR TITLE
Update HIP 1056 Block Streams with latest block items and proofs

### DIFF
--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -422,7 +422,7 @@ all implementations:
 | 5 | `transaction_result` | Output | Execution result for the preceding signed transaction |
 | 6 | `transaction_output` | Output | Supplementary output produced by transaction execution |
 | 7 | `state_changes` | State | Ledger state mutations (account, file, contract, etc.) |
-| 8 | `filtered_item_hash` | (variable) | SHA-384 hash of a redacted item (privacy-preserving streams) |
+| 8 | `filtered_single_item` | (variable) | In-stream replacement hash for a single filtered item (privacy-preserving streams) |
 | 9 | `block_proof` | (Not hashed) | Cryptographic proof of block integrity; closes the block |
 | 10 | `record_file` | (Not hashed) | Legacy V6 record-stream file carried for historical compatibility |
 | 11 | `trace_data` | Trace | EVM trace or diagnostic data |
@@ -435,7 +435,7 @@ Items marked "(Not hashed)" are parsed for metadata and control flow but do not 
 ```protobuf
 message BlockItem {
     // Reserved for future items that require separate handling for block hash purposes.
-    reserved 13,14,15,16,17,18;
+    reserved 13,14,15,16,17,18,20;
 
     oneof item {
         /**
@@ -517,7 +517,7 @@ message BlockItem {
 ```
 ##### Item Routing to Streaming Hashers
 
-All items in the block other than the final `BlockProof`, `BlockFooter`, a `RecordFileItem`, `FilteredItemHash`, or
+All items in the block other than the final `BlockProof`, `BlockFooter`, a `RecordFileItem`, `FilteredSingleItem`, or
 `RedactedItem` are assigned to one of five streaming Merkle hashers. This separation is important because items are
 hashed into five independent sub-merkle-trees that are combined to form the final block root hash.
 
@@ -531,12 +531,15 @@ To avoid storing redundant metadata in each item, the streaming hasher assignmen
 | `BlockHeader`, `TransactionResult`, `TransactionOutput` | `outputTreeHasher` |
 | `StateChanges` | `stateChangesHasher` |
 | `TraceData` | `traceDataHasher` |
-| `BlockProof`, `BlockFooter`, `RecordFileItem`, `FilteredItemHash`, `RedactedItem` | _(not hashed)_ |
+| `BlockProof`, `BlockFooter`, `RecordFileItem`, `FilteredSingleItem`, `RedactedItem` | _(not hashed)_ |
+
+Each hasher accumulates its items in stream order using the streaming binary tree algorithm defined in
+[HIP-1424](./hip-1424-block-stream-hashing.md), producing a subtree root hash incrementally as items arrive.
 
 This separation enables:
 
 - **Selective Filtering:** A downstream service can filter out items of certain types (e.g., all `TraceData`) and
-  replace them with `FilteredItemHash` values, without affecting the validity of the block proof.
+  replace them with `FilteredSingleItem` values, without affecting the validity of the block proof.
 - **Incremental Verification:** Each subtree can be verified independently or in parallel, allowing for optimized
   verification pipelines.
 - **Forward Compatibility:** New item types can be routed to existing hashers or new hashers (via the field-number
@@ -554,12 +557,12 @@ in the specification for Block Items, and repeated
 in [Forward Compatibility](#forward-compatibility) below.
 
 The division into subtrees also enables filtering of data based on data type or
-fine-grained content filters. For example a downstream services could filter for
+fine-grained content filters. For example a downstream service could filter for
 only transactional data if there is no requirement for event or state
 information. Another service could filter on only accounts they are interested
-in. Block items removed from a filtered stream are represented by one or more
-`FilteredItemHash`’s which provide the missing hashes required to validate the
-filtered stream with the same block proof as the full stream.
+in. Block items removed from a filtered stream are represented by `FilteredSingleItem`
+entries which preserve the missing hashes required to validate the filtered stream
+with the same block proof as the full stream.
 
 The parent-child relationship of some transactions is preserved in the Block
 Streams and will see the appropriate `BlockItem`s for each level. For example,
@@ -1579,71 +1582,85 @@ message QueuePopChange {
 > With that in mind, while intermediate states may temporarily diverge during block stream replay, the final state after
 > applying all state changes in a round will match the live network's state at that same round boundary.
 
-#### TraceData
-
-The `TraceData` block item carries execution trace and diagnostic data produced during transaction processing. This item
-type is particularly useful for EVM-compatible transactions: it includes EVM execution logs, call traces, and other
-operational details that are not needed to verify consensus or state changes but are valuable for developers debugging
-smart contracts or analyzing gas consumption.
-
-`TraceData` items are:
-- Hashed into the `traceDataHasher` subtree (leaf index 7 of the block Merkle tree).
-- Optional; a block may have zero, one, or many `TraceData` items depending on the transactions executed.
-- Associated with a preceding `TransactionResult` or `TransactionOutput` to indicate which transaction they describe.
-
-Downstream services may filter out `TraceData` entirely (replacing each with a `FilteredItemHash`) to reduce block stream
-size if they have no need for execution details.
-
-```protobuf
-message TraceData {
-    /**
-     * Trace information for a single transaction or contract invocation.
-     * The exact structure is implementation-specific and may include:
-     * - EVM call frames and stack traces
-     * - Gas consumption per opcode
-     * - Storage access logs
-     * - Event/log emissions
-     */
-    bytes trace_bytes = 1;
-}
-```
-
 #### FilteredBlockItem
 
 The block stream supports omitting `BlockItem`s from the stream while retaining full cryptographic verification of the
 block proof. This capability enables privacy-preserving block streams for jurisdictions, regulators, or operators with
 data-classification requirements (e.g., filtering PII, compliance data, or proprietary information).
 
-A `FilteredItemHash` is a **privacy-preserving replacement** for any `BlockItem`: when an item is filtered out, its
-position in the Merkle tree is preserved by substituting the item with a hash of its contents. This allows downstream
-nodes to:
+Because all items are hashed into subtree roots rather than used raw, removing an item and replacing it with a hash
+does not alter the cryptographic integrity of the block proof. A downstream verifier can:
 
 - Validate the block proof against the block root hash without seeing the filtered item's content.
 - Reconstruct the full Merkle tree using the provided hash, even though the item itself is redacted.
-- Verify that the block was indeed agreed upon by the network, independent of data visibility.
+- Verify that the block was agreed upon by the network, independent of data visibility.
 
-Because all items are hashed into subtree roots (not used raw), removing an item and replacing it with a hash does not
-alter the cryptographic integrity of the block proof.
+There are three filtering message types, each serving a different scope:
+
+**`FilteredSingleItem`** (field 8 in `BlockItem`) replaces a single filtered item in-stream. It carries the item's
+hash and the `SubMerkleTree` enum value indicating which subtree the item belongs to, so verifiers can route the hash
+to the correct hasher.
 
 ```protobuf
-message FilteredItemHash {
+message FilteredSingleItem {
     /**
-     * A hash of items filtered from the stream.
-     * This is the SHA-384 hash of the filtered item(s), used to reconstruct
-     * the Merkle subtree without disclosing the item's contents.
-    */
-    bytes hash = 1;
+     * The SHA-384 hash of the filtered item, computed the same way as if the
+     * item were present. The hash algorithm MUST match the block header.
+     */
+    bytes item_hash = 1;
 
     /**
-     * A binary tree path indicating where in the Merkle subtree this hash belongs.
+     * The subtree this item would have been routed to if present.
+     * Determines which streaming hasher receives this hash.
      */
-    uint64 filtered_path = 2;
+    SubMerkleTree tree = 2;
+}
+```
+
+**`FilteredMerkleSubTree`** replaces an entire subtree that has been filtered out with its pre-computed root hash and
+a count of the leaves it covered. Used when a whole category of items (e.g., all `TraceData`) is removed at once.
+
+```protobuf
+message FilteredMerkleSubTree {
+    /**
+     * Root hash of the filtered sub-merkle tree.
+     */
+    bytes subtree_root_hash = 1;
 
     /**
-     * The log2 value of the number of items represented by this hash.
-     * A value of 0 means a single item; a value of N means 2^N items.
+     * Which of the block's sub-merkle trees this hash represents.
      */
-    uint64 log2_item_count = 3;
+    SubMerkleTree tree = 2;
+
+    /**
+     * The number of leaf items filtered by this entry.
+     */
+    uint32 filtered_leaf_count = 3;
+}
+```
+
+**`RedactedItem`** (field 19 in `BlockItem`) is used when an item is redacted for privacy or compliance reasons. It
+differs from `FilteredSingleItem` in that it optionally carries the hash of the inner `SignedTransaction` separately,
+which is needed for event reconstruction without revealing the transaction content.
+
+```protobuf
+message RedactedItem {
+    /**
+     * The SHA-384 hash of the redacted item. Required.
+     */
+    bytes item_hash = 1;
+
+    /**
+     * For redacted SignedTransactions only: the hash of the raw transaction
+     * bytes (without the BlockItem wrapper), needed for event reconstruction.
+     * Omitted for synthetic transactions and non-transaction items.
+     */
+    bytes signed_transaction_hash = 2;
+
+    /**
+     * The subtree this item would have been routed to.
+     */
+    SubMerkleTree tree = 3;
 }
 ```
 
@@ -1652,134 +1669,170 @@ message FilteredItemHash {
 A filtered block stream is produced by:
 
 1. Starting with a full block stream.
-2. Removing items that match a privacy filter (e.g., “redact accounts matching this pattern”).
-3. For each removed item, injecting a `FilteredItemHash` at the same Merkle position.
+2. Removing items that match a privacy or data-classification filter.
+3. For each removed item, inserting a `FilteredSingleItem` at the same stream position; or, if an entire subtree is
+   removed, inserting a single `FilteredMerkleSubTree` in its place.
 
-A downstream verifier receiving a filtered stream can:
-
-- Verify the block proof using only the `FilteredItemHash` values (which function as leaf hashes).
-- Know that the full block passed verification at the network, even though it cannot see the filtered content.
-- Reconstruct the complete Merkle tree if it later obtains the filtered items from another source.
-
-> 💡 *Sidebar: Filtering and Errata for Block Stream.* Block stream supports filtering through `FilteredItemHash` and
-> correcting errors via errata transactions. Errata are handled by submitting a signed correction transaction from the
-> council, which is included in a later block and becomes part of that block's proof. This preserves transparency and
-> immutability: the original error and its correction are both visible in the block stream.
+> 💡 *Sidebar: Filtering and Errata.* Errata — corrections to historical data — are handled by the `amendments` field
+> on `RecordFileItem` for historical blocks. For live blocks, a corrective transaction is submitted to the network and
+> recorded in a subsequent block as a normal transaction, preserving full transparency and immutability.
 
 #### Block Proof and Merkle Tree Structure
 
 The block proof carries the trust of the consensus network to the contents of the block. A block's integrity is verified
-via a cryptographic proof that chains all contents—events, transactions, outputs, and state changes—into a single block
-root hash, signed by a threshold (>1/3 stake weight) of consensus nodes via a TSS-BLS aggregate signature.
+via a cryptographic proof that chains all contents — events, transactions, outputs, and state changes — into a single
+block root hash, signed by a threshold (>2/3 stake weight) of consensus nodes via a TSS-BLS aggregate signature.
 
 ##### Merkle Tree Topology
 
-Each block is verified against a fixed-structure **depth-5 binary Merkle tree** with **eight leaves**. All hashing uses
-**SHA-384** with domain-separated prefixes to ensure leaf and internal-node hashes occupy distinct hash spaces:
+Each block is verified against a binary Merkle tree whose right-most fixed subtree has **16 leaf slots**. The first 8
+slots carry active values; slots 9–16 (`FUTURE_1` through `FUTURE_8` in the `SubMerkleTree` enum) are reserved for
+future use and are treated as null leaves until defined by a future HIP. The hashing algorithm and domain-separation
+scheme are fully specified in [HIP-1424](./hip-1424-block-stream-hashing.md).
 
-- **Leaf prefix**: `0x00` – hash(0x00 ∥ leafData)
-- **Single-child internal node**: `0x01` – hash(0x01 ∥ childHash)
-- **Two-child internal node**: `0x02` – hash(0x02 ∥ leftHash ∥ rightHash)
+The 16 leaf slots correspond to the `SubMerkleTree` enum defined in `block_item.proto`:
 
-The eight leaf values (in left-to-right order) are:
+| `SubMerkleTree` value | Leaf | Name | Source | Description |
+|----------------------|------|------|--------|-------------|
+| `PREVIOUS_BLOCK_ROOT` (1) | 0 | `previous_block_root_hash` | BlockFooter | Root hash of block N−1 |
+| `PREVIOUS_ROOTS_TREE` (2) | 1 | `root_hash_of_all_block_hashes_tree` | BlockFooter | Incrementally-collapsed tree of all prior block root hashes |
+| `PREVIOUS_BLOCK_START_STATE` (3) | 2 | `start_of_block_state_root_hash` | BlockFooter | Merkle root of ledger state **at the start of block N** |
+| `CONSENSUS_HEADER_ITEMS` (4) | 3 | consensus headers | Streaming hasher | Root of RoundHeader and EventHeader items |
+| `INPUT_ITEMS_TREE` (5) | 4 | inputs | Streaming hasher | Root of SignedTransaction items |
+| `OUTPUT_ITEMS_TREE` (6) | 5 | outputs | Streaming hasher | Root of BlockHeader, TransactionResult, TransactionOutput items |
+| `STATE_CHANGE_ITEMS_TREE` (7) | 6 | state changes | Streaming hasher | Root of StateChanges items |
+| `TRACE_DATA_ITEMS_TREE` (8) | 7 | trace data | Streaming hasher | Root of TraceData items |
+| `FUTURE_1`–`FUTURE_8` (9–16) | 8–15 | _(reserved)_ | — | Null leaves; reserved for future HIP extension |
 
-| Leaf Index | Name | Source | Description |
-|------------|------|--------|-------------|
-| 0 | `previousBlockHash` | BlockFooter | Root hash of block N−1 |
-| 1 | `rootHashOfAllPreviousBlockHashes` | BlockFooter | Chained hash of all prior block hashes |
-| 2 | `stateRootHash` | BlockFooter | Merkle root of ledger state **at the start of block N** |
-| 3 | `rootOfConsensusHeaders` | Streaming hasher | Root of `consensusHeaderHasher` (RoundHeaders, EventHeaders) |
-| 4 | `rootOfInputs` | Streaming hasher | Root of `inputTreeHasher` (SignedTransactions) |
-| 5 | `rootOfOutputs` | Streaming hasher | Root of `outputTreeHasher` (BlockHeader, TransactionResults, TransactionOutputs) |
-| 6 | `rootOfStateChanges` | Streaming hasher | Root of `stateChangesHasher` (StateChanges items) |
-| 7 | `rootOfTraceData` | Streaming hasher | Root of `traceDataHasher` (TraceData items) |
-
-These eight leaves are combined via binary merkle logic to produce a single **block root hash**, which is then signed.
+These 16 leaves are combined to produce a single **block root hash**, which the consensus network then signs.
 
 > **State Root Hash Timing (EVM Compatibility):** The state root hash is deliberately captured at the **start** of
-> block N, not at the end. This is required for Ethereum Virtual Machine (EVM) compatibility: EVM transactions within
-> a block read the state as it existed before that block began, and EVM opcodes (e.g., `BLOCKHASH`) need immediate
-> access to recent prior block hashes. Computing the end-of-block state hash is I/O-intensive and would delay block
-> finalization. By storing the start-of-block state in block N's proof, the consensus node has the duration of one full
-> block to compute the end-of-block state hash, which becomes block N+1's start-of-block state. State proofs for the
-> changes *within* block N therefore require the `stateRootHash` field from block N+1.
-
-##### Five Streaming Hashers
-
-During block verification and generation, items are routed to five independent streaming hashers based on type:
-
-| Hasher | Item Types Routed | Purpose |
-|--------|-------------------|---------|
-| `inputTreeHasher` | `SignedTransaction` | Hashes all client and system transaction inputs |
-| `outputTreeHasher` | `BlockHeader`, `TransactionResult`, `TransactionOutput` | Hashes consensus metadata and transaction outputs |
-| `consensusHeaderHasher` | `RoundHeader`, `EventHeader` | Hashes consensus event and round metadata |
-| `stateChangesHasher` | `StateChanges` | Hashes ledger state mutations |
-| `traceDataHasher` | `TraceData` | Hashes EVM trace and diagnostic data |
-
-Items are hashed in the order they appear in the block stream. Each hasher independently maintains its subtree using a
-streaming binary tree algorithm, which allows root hashes to be computed incrementally as items arrive.
-
-Items marked as "not hashed" (`BlockProof`, `BlockFooter`, `FilteredItemHash`, `RedactedItem`, `RecordFileItem`) are
-parsed for metadata and control flow but do not feed into any streaming hasher.
+> block N, not at the end. This is required for EVM compatibility: EVM opcodes (e.g., `BLOCKHASH`) need immediate
+> access to recent prior block hashes and must read state as it existed before the block began. Computing the
+> end-of-block state hash is I/O-intensive; by storing the start-of-block state in block N's `BlockFooter`, the
+> consensus node gains one full block's worth of time to compute it. That end-of-block value becomes block N+1's
+> `start_of_block_state_root_hash`. State proofs for changes *within* block N therefore require the state root from
+> block N+1's `BlockFooter`.
 
 ##### Block Proof Forms
 
 There are three initial legitimate forms of `BlockProof`: `TssSignedBlockProof`, `StateProof` and `SignedRecordFileProof`
 
-###### 1. Tss Signed Block Proof
+###### 1. TssSignedBlockProof — Direct Aggregate Signature
 
-In the immediate aftermath of genesis or after a network cutover/key rotation event, a `TssSignedBlockProof` contains a direct
-**TSS-BLS aggregate signature** over the computed block root hash.
+The `TssSignedBlockProof` form contains a direct **TSS-BLS aggregate signature** over the computed block root hash.
+It is used when the consensus node can gather enough partial signatures from peers before producing the next block —
+which is the common case under normal network operation.
 
-This form is used when:
+The signature represents the aggregated partial signatures of nodes collectively holding >2/3 of the network's stake
+weight. Any party with the network's TSS public key (derivable from the ledger ID) can verify it. The exact subset
+of signing nodes is not recorded; only the threshold guarantee matters.
 
-- The network has just started (genesis block 0).
-- The network has recently undergone a cutover or key rotation, establishing a fresh TSS public key.
-- There is a prior block proof available to chain from.
+```protobuf
+message TssSignedBlockProof {
+    /**
+     * The TSS-BLS aggregate signature over the block root hash.
+     * Produced by aggregating partial signatures from nodes holding
+     * strictly greater than 2/3 of current network stake weight.
+     */
+    bytes block_signature = 1;
+}
+```
 
-The aggregate signature proves that a threshold (>1/3 stake weight) of consensus nodes independently computed and signed
-the same block root hash.
+###### 2. StateProof — Chained Merkle Proof
 
-In parallel the consensus network will calculate the compressed WRAPS proof for inclusion in a future block.
-Block stream subscribers need to be able to validate both
+The `StateProof` form is used when a direct aggregate signature for block M cannot be produced in time — for example,
+when signature fragments for block M are still arriving while block M+1 is already being finalized. Rather than
+stalling block production, the consensus node includes block M's root hash as a leaf in block M+1's Merkle tree.
+Block M+1 then carries a valid direct signature, and a `StateProof` in block M's `BlockProof` provides the
+`MerklePath` from block M's root hash up to block M+1's signed root.
 
-###### 2. State Proof
+A verifier walks the `MerklePath` sibling nodes from block M's root upward, recomputing parent hashes at each level,
+until reaching the root hash that is anchored by block M+1's `TssSignedBlockProof`. This cryptographically proves
+block M's integrity without requiring a direct signature on block M.
 
-In steady-state operation (after the first few blocks), a `BlockProof` for block M may reference a **later block N**
-(where N > M) instead of containing a direct signature on block M's hash. This form (sometimes called a "WRAPS" or
-chained proof) works as follows:
-
-1. The consensus node constructs block M and computes its block root hash.
-2. The consensus node cannot obtain a timely TSS signature on block M's root hash (e.g., due to network delays in
-   gathering signature fragments).
-3. Instead, the consensus node includes an ordered list of **sibling hashes** (`sibling_hashes` field) that form a
-   Merkle proof path from block M's root hash up to block N's root hash.
-4. The `BlockProof` for block M points to block N and carries the sibling hashes. Block N has a valid aggregate
-   signature.
-5. A verifier walks the sibling chain, recomputing parent hashes at each level, until reaching the root hash anchored by
-   block N's TSS signature. This cryptographically proves block M's integrity.
-
-This cascade mechanism allows the block stream to continue even if signature fragments for a block arrive late. The
-tradeoff is that cascade proofs are larger than direct aggregate signatures (due to the sibling hash list), but they
-are computationally faster to produce on the consensus node.
-
-The root hash of the block merkle tree is signed by the aggregate signature of the consensus network nodes. Thus proving
-the super majority of consensus nodes agree on the contents of this block, the state and all previous blocks. Consensus
-nodes will sign the root hash at the end of executing a block of transactions then gossip its signature fragments. It
-will then listen on gossip till it receives enough signature fragments from other nodes to produce an aggregate
-signature. The block proof item will not be produced and sent until that aggregate signature is created. This also means
-a consensus node will not begin to emit block items for future blocks until the current block can be proved.
+The root hash of the block Merkle tree is signed by the aggregate signature of the consensus network nodes, proving
+that a super-majority of consensus nodes agree on the contents of this block, the state, and all previous blocks.
+Consensus nodes sign the root hash at the end of executing a block, gossip their signature fragments, and wait until
+enough fragments arrive to produce an aggregate signature. The `BlockProof` item is not emitted until that aggregate
+signature is available.
 
 
-###### 3. Signed Record File Proof
+###### 3. SignedRecordFileProof — Historical Record File Blocks
 
-The block stream must support the ability to validate the complete historical ledger of the network.
-To support this the `SignedRecordFileProof` is provided and will contain the RSA signatures from consensus nodes for a
-block that was originally recorded in the record file format. It contains a list of signatures over the record file hash.
+`SignedRecordFileProof` exists to allow the complete historical ledger — every block produced before the block stream
+cutover — to be verified using the same `BlockProof` interface. Historical blocks carry the original RSA signatures
+that consensus nodes produced at the time each record file was created; no re-signing is performed.
 
-A block verifier should obtain the network address book at the time of the desired block from a trusted source.
-Using this a verifier can extract the consensus node public keys and verify that the record file hash of the record file
-contents in the block were signed by the nodes captured in the address book.
+```protobuf
+/**
+ * RSA signatures from consensus nodes over a record file hash.
+ * Used for blocks that wrap historical record files (pre-block-stream).
+ */
+message SignedRecordFileProof {
+    /**
+     * Record file format version (2, 5, or 6).
+     * Determines how the signed payload hash is computed (see below).
+     */
+    uint32 version = 1;
+
+    /**
+     * One entry per signing consensus node.
+     */
+    repeated RecordFileSignature record_file_signatures = 2;
+}
+
+message RecordFileSignature {
+    /**
+     * The RSA signature bytes (DER-encoded) from one consensus node
+     * over the record file hash for this block.
+     */
+    bytes signatures_bytes = 1;
+
+    /**
+     * The node ID of the consensus node that produced this signature.
+     * Used to look up the corresponding RSA public key in the address book.
+     */
+    uint64 node_id = 2;
+}
+```
+
+**Verification walkthrough**
+
+1. **Determine the signed payload.** The bytes that were RSA-signed depend on the record file format version
+   carried in `SignedRecordFileProof.version`:
+
+   | Version | Signed payload |
+   |---------|---------------|
+   | v6 | `SHA-384( int32(6) ∥ rawRecordStreamFileBytes )` |
+   | v5 | Reconstruct v5 binary record file from parsed items → `SHA-384(v5Bytes)` |
+   | v2 | Reconstruct v2 binary record → `SHA-384( SHA-384(v2Bytes) )` |
+
+   The `rawRecordStreamFileBytes` for v6 are the verbatim serialised proto bytes of the `RecordStreamFile`
+   contained in the `RecordFileItem`, not re-serialised from a parsed representation.
+
+2. **Obtain the address book at block time.** The address book active when the record file was created is
+   available on-chain at file `0.0.102` (a `NodeAddressBook` protobuf), which changes over time and must be
+   tracked chronologically. Each `NodeAddress` entry carries an `RSA_PubKey` field: a hex-encoded DER X.509
+   `SubjectPublicKeyInfo` string (no `0x` prefix). Historical address book snapshots are also included in the
+   `addressBookHistory.json` artifact produced by the WRB conversion process (see HIP-1427).
+
+3. **Verify each signature.** For each `RecordFileSignature`, look up the `PublicKey` for `node_id` in the
+   address book and verify using `SHA384withRSA`:
+   ```
+   Signature sig = Signature.getInstance("SHA384withRSA");
+   sig.initVerify(publicKey);
+   sig.update(computedPayload);   // 48-byte SHA-384 hash from step 1
+   boolean valid = sig.verify(signatureBytes);
+   ```
+
+4. **Check the acceptance threshold.** A block is accepted when the count of valid signatures meets the
+   supermajority of the active node roster at the time of the block:
+   ```
+   validatedCount >= floor(2/3 * rosterSize) + 1
+   ```
+   This matches the threshold used by Mirror Node and the WRB validation CLI. Stake-weighted threshold is a
+   future improvement.
 
 
 > 💡**Sidebar: Future extension**<br/>
@@ -1862,30 +1915,36 @@ Details:
 
 #### BlockFooter
 
-The `BlockFooter` is a metadata block item that precedes the `BlockProof` in the block stream. It carries the eight leaf
-values needed to assemble the block Merkle tree. The footer MUST be present in every block; verification cannot complete
-without it.
+The `BlockFooter` is a block item that immediately precedes the `BlockProof` in every block. It carries the first
+three leaf values of the block Merkle tree — the three hashes that come from outside the item stream and cannot be
+computed incrementally from block items alone. The footer MUST be present in every block; proof verification cannot
+complete without it.
+
+For historical wrapped record blocks, `start_of_block_state_root_hash` is set to 48 zero bytes because the state
+hash was not recorded in the original record stream at the time those blocks were created.
 
 ```protobuf
 message BlockFooter {
     /**
-     * The hash of the previous block's merkle root.
-     * This links the current block to the prior block, forming a chain.
+     * The root hash of the previous block's Merkle tree.
+     * Links this block to its predecessor, forming the block chain.
+     * SHALL be empty (48 zero bytes) for the stream-starting block.
      */
     bytes previous_block_root_hash = 1;
 
     /**
-     * The running hash of all previous block merkle roots.
-     * This is a hash chain: hash(hash(...hash(previousBlockRoot[0], previousBlockRoot[1]), ..., previousBlockRoot[N-1]).
-     * It provides a compact way to commit to the entire prior history.
+     * The root of an incrementally-collapsed Merkle tree containing the
+     * root hashes of all blocks from block zero up to but not including
+     * this block. See HIP-1424 for the incremental collapse algorithm.
      */
-    bytes root_hash_of_all_previous_block_hashes = 2;
+    bytes root_hash_of_all_block_hashes_tree = 2;
 
     /**
-     * The merkle root hash of the network state at the START of this block.
-     * This is the state root BEFORE the transactions in this block are applied.
-     * Required for EVM compatibility; the state hash for changes WITHIN this block
-     * is found in the next block's BlockFooter.
+     * The Merkle root hash of the network state at the START of this block
+     * (i.e., before any transactions in this block are applied).
+     * State-processing clients MUST validate applied state changes using
+     * the value in the FOLLOWING block's BlockFooter.
+     * Set to 48 zero bytes for historical wrapped record blocks.
      */
     bytes start_of_block_state_root_hash = 3;
 }
@@ -1893,89 +1952,81 @@ message BlockFooter {
 
 ##### BlockProof Protobuf Definition
 
-In the block streams output a block proof is represented as such:
+A `BlockProof` uses a `oneof proof` field to carry exactly one of the three proof forms described above:
 
 ```protobuf
 message BlockProof {
     /**
-     * The block number this proof covers.
-     * For aggregate-signature form proofs, this is the block being proven.
-     * For cascade-proof form, this may reference a prior block proven via sibling hashes.
+     * The block this proof secures.
+     * Under normal operation this matches the current block number.
+     * A StateProof may reference a later block that anchors this block's hash.
      */
     uint64 block = 1;
 
     /**
-     * An aggregate TSS-BLS signature over the block root hash.
-     * Present when the consensus node can produce a direct signature.
-     * Contains:
-     *   - blockSignature: the TSS aggregate signature bytes
-     * Absent when this block's proof is deferred (cascade proof case).
+     * Exactly one proof form MUST be present.
      */
-    TssSignedBlockProof signed_block_proof = 2;
-
-    /**
-     * (Legacy field; preserved for backward compatibility)
-     * A merkle root hash of the previous block.
-     * This field is redundant; the value is now in BlockFooter.previousBlockRootHash.
-     */
-    bytes previous_block_root_hash = 3 [deprecated=true];
-
-    /**
-     * (Legacy field; preserved for backward compatibility)
-     * The hash of the merkle tree root for the network state at the start of
-     * this block.
-     * This field is redundant; the value is now in BlockFooter.startOfBlockStateRootHash.
-     */
-    bytes start_of_block_state_root_hash = 4 [deprecated=true];
-
-    /**
-     * MerkleSiblingHash values forming a path from this block's root hash up to
-     * a later block that carries a valid signature.
-     * Present only in cascade-proof form (when signed_block_proof is absent).
-     * Allows block M to be proven via block N's signature (where N > M).
-     */
-    repeated MerkleSiblingHash sibling_hashes = 5;
-
-    /**
-     * (Reserved for future use)
-     * Verification metadata (scheme ID or explicit key).
-     */
-    oneof verification_reference {
+    oneof proof {
         /**
-         * The id of the TSS scheme this signature verifies under.
+         * A direct TSS-BLS aggregate signature over the block root hash.
+         * Used when signature fragments are gathered before the next block begins.
          */
-        uint64 scheme_id = 6;
+        TssSignedBlockProof signed_block_proof = 2;
 
         /**
-         * The explicit TSS public key this signature verifies under.
+         * A chained Merkle proof linking this block's root hash into a later
+         * block that carries a direct TSS signature. Used when signature
+         * fragments arrive too late for a direct signature on this block.
          */
-        bytes verification_key = 7;
+        StateProof block_state_proof = 3;
+
+        /**
+         * RSA signatures from consensus nodes over the record file hash.
+         * Used only for blocks that wrap historical record files (pre-block-stream).
+         */
+        SignedRecordFileProof signed_record_file_proof = 4;
     }
 }
 
 /**
- * An aggregate TSS-BLS signature over a block root hash.
+ * A direct TSS-BLS aggregate signature over a block root hash.
+ * Produced by aggregating partial signatures from nodes holding
+ * strictly greater than 2/3 of current network stake weight.
  */
 message TssSignedBlockProof {
-    /**
-     * The aggregate TSS-BLS signature covering the block root hash.
-     * Verifying this signature with the network's TSS public key
-     * (derived from the ledger ID) proves that a threshold (>1/3 stake weight)
-     * of consensus nodes agreed on this block's contents.
-     */
-    bytes blockSignature = 1;
+    bytes block_signature = 1;
 }
 
-message MerkleSiblingHash {
-    /**
-    * True if this MerkleSiblingHash is the first hash in a pair of siblings, false if it is the second hash.
-    */
-    bool is_first = 1;
+/**
+ * A chained Merkle proof.
+ * Contains one or more MerklePaths linking this block's root hash into a
+ * later signed block, plus that later block's TssSignedBlockProof.
+ */
+message StateProof {
+    repeated MerklePath paths = 1;
+    oneof proof {
+        TssSignedBlockProof signed_block_proof = 2;
+    }
+}
 
-    /**
-    * BlockHashType(SHA_384) hash for the sibling at this level of the merkle tree.
-    */
-    bytes sibling_hash = 2;
+/**
+ * A path from a node in a Merkle tree to the root of that tree,
+ * used to prove a block's root hash is contained in a later signed block.
+ */
+message MerklePath {
+    repeated SiblingNode siblings = 1;
+    uint32 next_path_index = 2;    // index into StateProof.paths; UINT32_MAX at root
+    oneof content {
+        bytes hash            = 3; // hash of an internal node or block root
+        bytes state_item_leaf = 4; // StateItem leaf content
+        bytes block_item_leaf = 5; // BlockItem leaf content
+        bytes timestamp_leaf  = 6; // Timestamp leaf content
+    }
+}
+
+message SiblingNode {
+    bool  is_left = 1;  // true if this sibling is the left child
+    bytes hash    = 2;
 }
 ```
 
@@ -2041,32 +2092,45 @@ message RecordFileItem {
 
     /**
     * The contents of a record file.
+    * This is the full parsed record stream file from the legacy format.
     */
-    bytes record_file_contents = 2;
+    proto.RecordStreamFile record_file_contents = 2;
 
     /**
     * The contents of sidecar files for this block.
     */
-    repeated SidecarFile sidecar_file = 3;
+    repeated proto.SidecarFile sidecar_file_contents = 3;
 
     /**
-    * A collection of RSA signatures from consensus nodes.
-    * The first 4 bytes are a 32bit little endian version number and multiple version exist including v2, v5 and v6
+    * Errata for this record file: additions and record replacements
+    * that correct historical data errors discovered after the original
+    * record file was produced and signed.
     */
-    repeated bytes record_file_hash_signatures = 4;
+    repeated proto.RecordStreamItem amendments = 4;
 }
 
 ```
 
+The `amendments` field (field 4) carries errata for the wrapped record block. When a historical data error is discovered post-signing, corrections cannot be applied by re-signing the original record file (the original RSA signatures must remain intact for the `SignedRecordFileProof` to verify). Instead, corrective entries are appended as `amendments`: a list of `RecordStreamItem` additions and replacements that supersede the corresponding items in `record_file_contents`. Consumers of `RecordFileItem` SHOULD apply amendments before processing the record file contents.
+
 #### TraceData
 
-A `TraceData` block item is added to contain all information that could be cosnidered trace or debugging in nature.
-The consensus node will export all necessary and important data for a transactions execution in the block streams,
-however every byte of information is stored fore er and needed in the proof of the network data. As such it's important
-to ensure that data is required but also laid out in a way that makes it easier for filtering by downstream clients.
-To this point the `TraceData` would initially contain smart contracts `EvmTraceData` that support traceability information (e.g.
-contract actions, read values etc). Future trace like data can be added to `TraceData` and Block Nodes, Mirror Nodes and
-other block stream clients can decided to store or filter it out based on their needs.
+The `TraceData` block item carries execution trace and diagnostic data produced during transaction processing. This item
+type is particularly useful for EVM-compatible transactions: it includes EVM execution logs, call traces, and other
+operational details that are not needed to verify consensus or state changes but are valuable for developers debugging
+smart contracts or analyzing gas consumption.
+
+`TraceData` items are:
+- Hashed into the `traceDataHasher` subtree (leaf index 7 of the block Merkle tree, `TRACE_DATA_ITEMS_TREE`).
+- Optional; a block may have zero, one, or many `TraceData` items depending on the transactions executed.
+- Associated with a preceding `TransactionResult` or `TransactionOutput` to indicate which transaction they describe.
+
+Downstream services may filter out `TraceData` entirely (replacing each with a `FilteredSingleItem`) to reduce block stream
+size if they have no need for execution details. Future trace-like data can be added to `TraceData` and block stream
+clients can decide to store or discard it based on their needs.
+
+Initially, `TraceData` contains EVM smart contract traceability data via the `EvmTraceData` sub-message (contract
+actions, slot usages, error details, initcode, and events).
 
 ```protobuf
 /**

--- a/HIP/hip-1056.md
+++ b/HIP/hip-1056.md
@@ -406,13 +406,36 @@ considerations, in addition to the end of a `Block` or `Transaction`.
 
 #### BlockItem
 
-A block item is a logical separation of components that together make up a block. A Block item will fall into one of 3
-categories - input, output or other. A Block item may be one of the 10 initial types noted below.
+A block item is a logical separation of components that together make up a block. A block item falls into one of multiple
+categories based on its role in the block structure: event/round headers (consensus), transaction inputs, transaction
+outputs/results, state changes, trace data, or administrative items (proofs, filtered hashes, legacy records).
+
+The `BlockItem` message defines 13 oneof cases, enumerated below. These 13 types are normative and SHALL be recognized by
+all implementations:
+
+| Field # | Type | Routing Category | Description |
+|---------|------|------------------|-------------|
+| 1 | `block_header` | Output | Opens a block; carries block number, timestamp, hash algorithm |
+| 2 | `event_header` | Consensus | Opens a consensus event within a round |
+| 3 | `round_header` | Consensus | Opens a consensus round |
+| 4 | `signed_transaction` | Input | A single transaction submitted by a client or system |
+| 5 | `transaction_result` | Output | Execution result for the preceding signed transaction |
+| 6 | `transaction_output` | Output | Supplementary output produced by transaction execution |
+| 7 | `state_changes` | State | Ledger state mutations (account, file, contract, etc.) |
+| 8 | `filtered_item_hash` | (variable) | SHA-384 hash of a redacted item (privacy-preserving streams) |
+| 9 | `block_proof` | (Not hashed) | Cryptographic proof of block integrity; closes the block |
+| 10 | `record_file` | (Not hashed) | Legacy V6 record-stream file carried for historical compatibility |
+| 11 | `trace_data` | Trace | EVM trace or diagnostic data |
+| 12 | `block_footer` | (Not hashed) | Carries `startOfBlockStateRootHash`; precedes `block_proof` |
+| 19 | `redacted_item` | (Not hashed) | Placeholder for a fully redacted item |
+
+Items in categories Input, Output, Consensus, State, and Trace are hashed into five separate streaming merkle subtrees.
+Items marked "(Not hashed)" are parsed for metadata and control flow but do not contribute to any merkle subtree.
 
 ```protobuf
 message BlockItem {
     // Reserved for future items that require separate handling for block hash purposes.
-    reserved 12,13,14,15,16,17,18,19;
+    reserved 13,14,15,16,17,18;
 
     oneof item {
         /**
@@ -478,13 +501,48 @@ message BlockItem {
          * Trace data.
          */
         TraceData trace_data = 11;
+
+        /**
+         * Block footer containing metadata used in block finalization.
+         */
+        com.hedera.hapi.block.stream.output.BlockFooter block_footer = 12;
+
+        /**
+         * A redacted block item; used when an item is filtered from a privacy-preserving stream.
+         */
+        RedactedItem redacted_item = 19;
     }
 }
 
 ```
-All items in the block other than the final `BlockProof`, a `RecordFileItem`, or
-a `FilteredItemHash` are assigned to specific subtrees. This separation is
-important as they are hashed into different sub-merkle-trees in the final proof.
+##### Item Routing to Streaming Hashers
+
+All items in the block other than the final `BlockProof`, `BlockFooter`, a `RecordFileItem`, `FilteredItemHash`, or
+`RedactedItem` are assigned to one of five streaming Merkle hashers. This separation is important because items are
+hashed into five independent sub-merkle-trees that are combined to form the final block root hash.
+
+To avoid storing redundant metadata in each item, the streaming hasher assignment is defined by **item type**
+(not by field number). The routing is as follows:
+
+| Item Type | Streaming Hasher |
+|-----------|------------------|
+| `RoundHeader`, `EventHeader` | `consensusHeaderHasher` |
+| `SignedTransaction` | `inputTreeHasher` |
+| `BlockHeader`, `TransactionResult`, `TransactionOutput` | `outputTreeHasher` |
+| `StateChanges` | `stateChangesHasher` |
+| `TraceData` | `traceDataHasher` |
+| `BlockProof`, `BlockFooter`, `RecordFileItem`, `FilteredItemHash`, `RedactedItem` | _(not hashed)_ |
+
+This separation enables:
+
+- **Selective Filtering:** A downstream service can filter out items of certain types (e.g., all `TraceData`) and
+  replace them with `FilteredItemHash` values, without affecting the validity of the block proof.
+- **Incremental Verification:** Each subtree can be verified independently or in parallel, allowing for optimized
+  verification pipelines.
+- **Forward Compatibility:** New item types can be routed to existing hashers or new hashers (via the field-number
+  extension mechanism below) without requiring all implementations to be updated simultaneously.
+
+All items in the block are hashed into different sub-merkle-trees in the final proof.
 We did not want to carry, in each block item, data representing which tree it
 was hashed in as that would waste a lot of bytes and also require excess
 parsing. Therefore, the subtree to use is defined by a convention for the _field
@@ -1521,69 +1579,189 @@ message QueuePopChange {
 > With that in mind, while intermediate states may temporarily diverge during block stream replay, the final state after
 > applying all state changes in a round will match the live network's state at that same round boundary.
 
+#### TraceData
+
+The `TraceData` block item carries execution trace and diagnostic data produced during transaction processing. This item
+type is particularly useful for EVM-compatible transactions: it includes EVM execution logs, call traces, and other
+operational details that are not needed to verify consensus or state changes but are valuable for developers debugging
+smart contracts or analyzing gas consumption.
+
+`TraceData` items are:
+- Hashed into the `traceDataHasher` subtree (leaf index 7 of the block Merkle tree).
+- Optional; a block may have zero, one, or many `TraceData` items depending on the transactions executed.
+- Associated with a preceding `TransactionResult` or `TransactionOutput` to indicate which transaction they describe.
+
+Downstream services may filter out `TraceData` entirely (replacing each with a `FilteredItemHash`) to reduce block stream
+size if they have no need for execution details.
+
+```protobuf
+message TraceData {
+    /**
+     * Trace information for a single transaction or contract invocation.
+     * The exact structure is implementation-specific and may include:
+     * - EVM call frames and stack traces
+     * - Gas consumption per opcode
+     * - Storage access logs
+     * - Event/log emissions
+     */
+    bytes trace_bytes = 1;
+}
+```
+
 #### FilteredBlockItem
 
-The block stream will support the ability to omit `BlockItem`s from the stream while retaining full verification of the
-block proof. This is possible because all items are double hashed. Their hash is hashed into the parent node not the raw
-contents of the item. The block proof is based on the signing of the root hash of a block merkle tree, therefore any
-item or subtree in the proof can be replaced by a `FilteredItemHash`. Notably, the replacement of an item with a hash
-will not impact the ability for downstream services to validate block proofs.
+The block stream supports omitting `BlockItem`s from the stream while retaining full cryptographic verification of the
+block proof. This capability enables privacy-preserving block streams for jurisdictions, regulators, or operators with
+data-classification requirements (e.g., filtering PII, compliance data, or proprietary information).
 
+A `FilteredItemHash` is a **privacy-preserving replacement** for any `BlockItem`: when an item is filtered out, its
+position in the Merkle tree is preserved by substituting the item with a hash of its contents. This allows downstream
+nodes to:
+
+- Validate the block proof against the block root hash without seeing the filtered item's content.
+- Reconstruct the full Merkle tree using the provided hash, even though the item itself is redacted.
+- Verify that the block was indeed agreed upon by the network, independent of data visibility.
+
+Because all items are hashed into subtree roots (not used raw), removing an item and replacing it with a hash does not
+alter the cryptographic integrity of the block proof.
 
 ```protobuf
 message FilteredItemHash {
     /**
      * A hash of items filtered from the stream.
+     * This is the SHA-384 hash of the filtered item(s), used to reconstruct
+     * the Merkle subtree without disclosing the item's contents.
     */
     bytes hash = 1;
-    
+
     /**
-    * A binary tree path to a merkle subtree.
-    */
+     * A binary tree path indicating where in the Merkle subtree this hash belongs.
+     */
     uint64 filtered_path = 2;
 
     /**
-     * The log2 value of the number of filtered items.<br/>
+     * The log2 value of the number of items represented by this hash.
+     * A value of 0 means a single item; a value of N means 2^N items.
      */
     uint64 log2_item_count = 3;
 }
 ```
-> 💡 *Sidebar: Filtering and Errata for Block Stream.* Block stream supports
-> filtering the block stream through the use of a `FilteredItemHash` to replace
-> any item or subtree that has been removed. The removed subtree is replaced by
-> its hash and the path that was filtered which preserves the ability to verify
-> the integrity of the block stream and block proof. Errata are handled similarly
-> for removed items. Adding items *after the fact* or replacing an erroneous item
-> requires potentially removing a prior item, and adding the correction (errata)
-> as a new item in the block stream at the point of the “errata” transaction,
-> which is then part of the block proof for the block where the “errata” was
-> processed.
 
-#### Block Proof
+##### Usage: Filtered Streams
 
-The block proof carries the trust of the consensus network to the contents of the block. A block can conceptually be
-represented as a binary merkle tree with 8 sub-trees at depth 3 which create the block proof and tree when hashed to
-obtain a merkle root.
+A filtered block stream is produced by:
 
-![Root Hashes](../assets/hip-1056/root-hashes.svg)
+1. Starting with a full block stream.
+2. Removing items that match a privacy filter (e.g., “redact accounts matching this pattern”).
+3. For each removed item, injecting a `FilteredItemHash` at the same Merkle position.
 
-The 8 leaves (with associated merkle binary path numbers) represent
+A downstream verifier receiving a filtered stream can:
 
-1. (000) Previous block proof hash - the root of previous blocks merkle tree, this forms a blockchain
-2. (001) Merkle root of state tree  - root hash of consensus node state merkle tree at the beginning before the state changes
-   of the block are applied
-3. (010) Merkle root of consensus header tree - root hash of combined round and event header items merkle tree
-4. (011) Merkle root of transaction inputs tree - root hash of input item merkle tree
-5. (100) Merkle root of transaction outputs tree - root hash of output item merkle tree
-6. (101) Merkle root of state changes outputs tree - root hash of state changes output merkle tree
-7. (110) Merkle root of trace data outputs tree - root hash of trace data item merkle tree
-8. (111) Merkle root of extensions subtree - root of a depth 2 subtree for up to 4 additional "future"
-   subtrees. These subtrees are pre-defined to support efficient forward-compatibility. Until these
-   extensions are defined in a future HIP, the leaves of this tree are all `NULL`.
-    1. (1100) Merkle root of extension 0
-    2. (1101) Merkle root of extension 1
-    3. (1110) Merkle root of extension 2
-    4. (1111) Merkle root of extension 3
+- Verify the block proof using only the `FilteredItemHash` values (which function as leaf hashes).
+- Know that the full block passed verification at the network, even though it cannot see the filtered content.
+- Reconstruct the complete Merkle tree if it later obtains the filtered items from another source.
+
+> 💡 *Sidebar: Filtering and Errata for Block Stream.* Block stream supports filtering through `FilteredItemHash` and
+> correcting errors via errata transactions. Errata are handled by submitting a signed correction transaction from the
+> council, which is included in a later block and becomes part of that block's proof. This preserves transparency and
+> immutability: the original error and its correction are both visible in the block stream.
+
+#### Block Proof and Merkle Tree Structure
+
+The block proof carries the trust of the consensus network to the contents of the block. A block's integrity is verified
+via a cryptographic proof that chains all contents—events, transactions, outputs, and state changes—into a single block
+root hash, signed by a threshold (>1/3 stake weight) of consensus nodes via a TSS-BLS aggregate signature.
+
+##### Merkle Tree Topology
+
+Each block is verified against a fixed-structure **depth-5 binary Merkle tree** with **eight leaves**. All hashing uses
+**SHA-384** with domain-separated prefixes to ensure leaf and internal-node hashes occupy distinct hash spaces:
+
+- **Leaf prefix**: `0x00` – hash(0x00 ∥ leafData)
+- **Single-child internal node**: `0x01` – hash(0x01 ∥ childHash)
+- **Two-child internal node**: `0x02` – hash(0x02 ∥ leftHash ∥ rightHash)
+
+The eight leaf values (in left-to-right order) are:
+
+| Leaf Index | Name | Source | Description |
+|------------|------|--------|-------------|
+| 0 | `previousBlockHash` | BlockFooter | Root hash of block N−1 |
+| 1 | `rootHashOfAllPreviousBlockHashes` | BlockFooter | Chained hash of all prior block hashes |
+| 2 | `stateRootHash` | BlockFooter | Merkle root of ledger state **at the start of block N** |
+| 3 | `rootOfConsensusHeaders` | Streaming hasher | Root of `consensusHeaderHasher` (RoundHeaders, EventHeaders) |
+| 4 | `rootOfInputs` | Streaming hasher | Root of `inputTreeHasher` (SignedTransactions) |
+| 5 | `rootOfOutputs` | Streaming hasher | Root of `outputTreeHasher` (BlockHeader, TransactionResults, TransactionOutputs) |
+| 6 | `rootOfStateChanges` | Streaming hasher | Root of `stateChangesHasher` (StateChanges items) |
+| 7 | `rootOfTraceData` | Streaming hasher | Root of `traceDataHasher` (TraceData items) |
+
+These eight leaves are combined via binary merkle logic to produce a single **block root hash**, which is then signed.
+
+> **State Root Hash Timing (EVM Compatibility):** The state root hash is deliberately captured at the **start** of
+> block N, not at the end. This is required for Ethereum Virtual Machine (EVM) compatibility: EVM transactions within
+> a block read the state as it existed before that block began, and EVM opcodes (e.g., `BLOCKHASH`) need immediate
+> access to recent prior block hashes. Computing the end-of-block state hash is I/O-intensive and would delay block
+> finalization. By storing the start-of-block state in block N's proof, the consensus node has the duration of one full
+> block to compute the end-of-block state hash, which becomes block N+1's start-of-block state. State proofs for the
+> changes *within* block N therefore require the `stateRootHash` field from block N+1.
+
+##### Five Streaming Hashers
+
+During block verification and generation, items are routed to five independent streaming hashers based on type:
+
+| Hasher | Item Types Routed | Purpose |
+|--------|-------------------|---------|
+| `inputTreeHasher` | `SignedTransaction` | Hashes all client and system transaction inputs |
+| `outputTreeHasher` | `BlockHeader`, `TransactionResult`, `TransactionOutput` | Hashes consensus metadata and transaction outputs |
+| `consensusHeaderHasher` | `RoundHeader`, `EventHeader` | Hashes consensus event and round metadata |
+| `stateChangesHasher` | `StateChanges` | Hashes ledger state mutations |
+| `traceDataHasher` | `TraceData` | Hashes EVM trace and diagnostic data |
+
+Items are hashed in the order they appear in the block stream. Each hasher independently maintains its subtree using a
+streaming binary tree algorithm, which allows root hashes to be computed incrementally as items arrive.
+
+Items marked as "not hashed" (`BlockProof`, `BlockFooter`, `FilteredItemHash`, `RedactedItem`, `RecordFileItem`) are
+parsed for metadata and control flow but do not feed into any streaming hasher.
+
+##### Block Proof Forms
+
+There are three initial legitimate forms of `BlockProof`: `TssSignedBlockProof`, `StateProof` and `SignedRecordFileProof`
+
+###### 1. Tss Signed Block Proof
+
+In the immediate aftermath of genesis or after a network cutover/key rotation event, a `TssSignedBlockProof` contains a direct
+**TSS-BLS aggregate signature** over the computed block root hash.
+
+This form is used when:
+
+- The network has just started (genesis block 0).
+- The network has recently undergone a cutover or key rotation, establishing a fresh TSS public key.
+- There is a prior block proof available to chain from.
+
+The aggregate signature proves that a threshold (>1/3 stake weight) of consensus nodes independently computed and signed
+the same block root hash.
+
+In parallel the consensus network will calculate the compressed WRAPS proof for inclusion in a future block.
+Block stream subscribers need to be able to validate both
+
+###### 2. State Proof
+
+In steady-state operation (after the first few blocks), a `BlockProof` for block M may reference a **later block N**
+(where N > M) instead of containing a direct signature on block M's hash. This form (sometimes called a "WRAPS" or
+chained proof) works as follows:
+
+1. The consensus node constructs block M and computes its block root hash.
+2. The consensus node cannot obtain a timely TSS signature on block M's root hash (e.g., due to network delays in
+   gathering signature fragments).
+3. Instead, the consensus node includes an ordered list of **sibling hashes** (`sibling_hashes` field) that form a
+   Merkle proof path from block M's root hash up to block N's root hash.
+4. The `BlockProof` for block M points to block N and carries the sibling hashes. Block N has a valid aggregate
+   signature.
+5. A verifier walks the sibling chain, recomputing parent hashes at each level, until reaching the root hash anchored by
+   block N's TSS signature. This cryptographically proves block M's integrity.
+
+This cascade mechanism allows the block stream to continue even if signature fragments for a block arrive late. The
+tradeoff is that cascade proofs are larger than direct aggregate signatures (due to the sibling hash list), but they
+are computationally faster to produce on the consensus node.
 
 The root hash of the block merkle tree is signed by the aggregate signature of the consensus network nodes. Thus proving
 the super majority of consensus nodes agree on the contents of this block, the state and all previous blocks. Consensus
@@ -1591,6 +1769,18 @@ nodes will sign the root hash at the end of executing a block of transactions th
 will then listen on gossip till it receives enough signature fragments from other nodes to produce an aggregate
 signature. The block proof item will not be produced and sent until that aggregate signature is created. This also means
 a consensus node will not begin to emit block items for future blocks until the current block can be proved.
+
+
+###### 3. Signed Record File Proof
+
+The block stream must support the ability to validate the complete historical ledger of the network.
+To support this the `SignedRecordFileProof` is provided and will contain the RSA signatures from consensus nodes for a
+block that was originally recorded in the record file format. It contains a list of signatures over the record file hash.
+
+A block verifier should obtain the network address book at the time of the desired block from a trusted source.
+Using this a verifier can extract the consensus node public keys and verify that the record file hash of the record file
+contents in the block were signed by the nodes captured in the address book.
+
 
 > 💡**Sidebar: Future extension**<br/>
 > The future extensions subtree allows for new subtrees to be defined in the
@@ -1670,49 +1860,110 @@ Details:
     - They could hash more than one stream to lower latency in the case where the chosen source node is bad but that
       will waste a lot of CPU for a rare case and is probably unwise.
 
-In the block streams output a block proof is represented as such
+#### BlockFooter
+
+The `BlockFooter` is a metadata block item that precedes the `BlockProof` in the block stream. It carries the eight leaf
+values needed to assemble the block Merkle tree. The footer MUST be present in every block; verification cannot complete
+without it.
+
+```protobuf
+message BlockFooter {
+    /**
+     * The hash of the previous block's merkle root.
+     * This links the current block to the prior block, forming a chain.
+     */
+    bytes previous_block_root_hash = 1;
+
+    /**
+     * The running hash of all previous block merkle roots.
+     * This is a hash chain: hash(hash(...hash(previousBlockRoot[0], previousBlockRoot[1]), ..., previousBlockRoot[N-1]).
+     * It provides a compact way to commit to the entire prior history.
+     */
+    bytes root_hash_of_all_previous_block_hashes = 2;
+
+    /**
+     * The merkle root hash of the network state at the START of this block.
+     * This is the state root BEFORE the transactions in this block are applied.
+     * Required for EVM compatibility; the state hash for changes WITHIN this block
+     * is found in the next block's BlockFooter.
+     */
+    bytes start_of_block_state_root_hash = 3;
+}
+```
+
+##### BlockProof Protobuf Definition
+
+In the block streams output a block proof is represented as such:
+
 ```protobuf
 message BlockProof {
     /**
-     * The block this proof secures.<br/>
-     * We provide this because a proof for a future block can be used to prove
-     * the state of the ledger at that block and the blocks before it.
+     * The block number this proof covers.
+     * For aggregate-signature form proofs, this is the block being proven.
+     * For cascade-proof form, this may reference a prior block proven via sibling hashes.
      */
     uint64 block = 1;
 
     /**
-     * A merkle root hash of the previous block.
+     * An aggregate TSS-BLS signature over the block root hash.
+     * Present when the consensus node can produce a direct signature.
+     * Contains:
+     *   - blockSignature: the TSS aggregate signature bytes
+     * Absent when this block's proof is deferred (cascade proof case).
      */
-    bytes previous_block_root_hash = 2;
+    TssSignedBlockProof signed_block_proof = 2;
 
     /**
+     * (Legacy field; preserved for backward compatibility)
+     * A merkle root hash of the previous block.
+     * This field is redundant; the value is now in BlockFooter.previousBlockRootHash.
+     */
+    bytes previous_block_root_hash = 3 [deprecated=true];
+
+    /**
+     * (Legacy field; preserved for backward compatibility)
      * The hash of the merkle tree root for the network state at the start of
      * this block.
+     * This field is redundant; the value is now in BlockFooter.startOfBlockStateRootHash.
      */
-    bytes start_of_block_state_root_hash = 3;
+    bytes start_of_block_state_root_hash = 4 [deprecated=true];
 
     /**
-     * A network signature of the block root hash.
-     */
-    bytes block_signature = 4;
-
-    /**
-     * MerkleSiblingHash's starting from the root hash of the signed block down to and including the sibling of this
-     * blocks root hash. Provided when for some reason a block signature for this block could not be produced.
+     * MerkleSiblingHash values forming a path from this block's root hash up to
+     * a later block that carries a valid signature.
+     * Present only in cascade-proof form (when signed_block_proof is absent).
+     * Allows block M to be proven via block N's signature (where N > M).
      */
     repeated MerkleSiblingHash sibling_hashes = 5;
-    
+
+    /**
+     * (Reserved for future use)
+     * Verification metadata (scheme ID or explicit key).
+     */
     oneof verification_reference {
         /**
-         * The id of the hinTS scheme this signature verifies under.
+         * The id of the TSS scheme this signature verifies under.
          */
         uint64 scheme_id = 6;
 
         /**
-         * The explicit hinTS key this signature verifies under
+         * The explicit TSS public key this signature verifies under.
          */
         bytes verification_key = 7;
     }
+}
+
+/**
+ * An aggregate TSS-BLS signature over a block root hash.
+ */
+message TssSignedBlockProof {
+    /**
+     * The aggregate TSS-BLS signature covering the block root hash.
+     * Verifying this signature with the network's TSS public key
+     * (derived from the ledger ID) proves that a threshold (>1/3 stake weight)
+     * of consensus nodes agreed on this block's contents.
+     */
+    bytes blockSignature = 1;
 }
 
 message MerkleSiblingHash {
@@ -2104,6 +2355,42 @@ In the past the exchange_rate details were in the transaction record. However, t
 and is based on the value of a system file `0.0.112`. Changes to this file are externalized in the block stream, thus
 the current exchange rate value is always available via a MN (and future BN). Thus it is no longer necessary to store
 the `exchange_rate` in the stream and we can remove unnecessary data from the block stream.
+
+### Capturing State Root at End-of-Block Rather Than Start-of-Block
+A design decision was made to capture the state merkle root at the **start** of the block (i.e., the end of the prior
+block) rather than at the end of the block. While end-of-block state would be more intuitive, it conflicts with EVM
+compatibility requirements: EVM transactions read state as it existed *before* the block began, and EVM opcodes require
+immediate access to recent prior block hashes via the `BLOCKHASH` opcode. Computing the end-of-block state hash is
+computationally expensive and would delay block finalization. By deferring the state root to the next block, the
+consensus node gains one full block's latency to compute the hash, balancing EVM compatibility with performance goals.
+The tradeoff is that state proofs require looking ahead to the next block's state root; however, the data needed to
+verify the proof is self-contained within the block.
+
+### Two Forms of TsssignedBlockProof (Aggregate Signature vs. WRAPS Proof)
+The block stream supports two forms of TSS block proofs to handle varying network conditions:
+
+- **Aggregate Signature Form** (direct proof): The consensus node computes a TSS-BLS aggregate signature directly over
+  the block's root hash. This is the preferred form and is used immediately after genesis and network cutover.
+
+- **State Proof Form** (chained proof): If the consensus node cannot obtain sufficient signature fragments for a block
+  in time, it includes a list of sibling hashes that form a Merkle path linking the block's root hash to a later block
+  that *does* have a valid aggregate signature. This allows the block stream to continue without blocking, at the cost
+  of a larger proof size.
+
+This dual-form design prevents signature-fragment delays from stalling block production while maintaining full
+cryptographic assurance.
+
+### Five Independent Streaming Hashers for Subtree Separation
+The block stream routes items to five independent streaming hashers (input, output, consensus headers, state changes,
+trace data) based on item type. This separation enables:
+
+- **Fine-grained Filtering:** A downstream service can filter out certain item types (e.g., trace data) without
+  recomputing the entire Merkle tree.
+- **Efficient Parallel Verification:** Each subtree can be verified independently or in parallel.
+- **Forward Compatibility:** Future item types can be added to new hashers without disrupting existing ones.
+
+An alternative design would have hashed all items into a single tree, but this would prevent selective filtering and
+reduce modularity for future extensions.
 
 ### Changing `EthereumOutput` to `EVMOutput`
 `EthereumOutput` seemed more appropriate if called `EVMOutput`. However, this is a legacy item referring ot the


### PR DESCRIPTION
## Description
This update brings HIP-1056 (Block Streams) in line with the current implementation of
block items, the block Merkle tree, and the three forms of `BlockProof`. The changes are
entirely specification and documentation; no on-chain behaviour is altered.

---

## What Changed

### 1. `BlockItem` type table — expanded from 10 to 13 types

The `BlockItem` message now formally defines 13 `oneof` cases with a routing-category
table covering each item's role (Input, Output, Consensus, State, Trace, or not-hashed).
Two new types are specified:

- **`BlockFooter` (field 12)** — carries the three leaf values needed to assemble the
  block Merkle tree (`previousBlockRootHash`, `rootHashOfAllPreviousBlockHashes`,
  `startOfBlockStateRootHash`). Precedes `BlockProof` in every block.
- **`RedactedItem` (field 19)** — placeholder for a fully redacted item in
  privacy-preserving streams.

The `reserved` field list is updated accordingly (fields 13–18 remain reserved; field 12
is now assigned).

---

### 2. Item routing to five streaming hashers — now normative

The five streaming hashers (`inputTreeHasher`, `outputTreeHasher`,
`consensusHeaderHasher`, `stateChangesHasher`, `traceDataHasher`) and their item-type
routing rules are now documented in a normative table. The section clarifies that routing
is determined by **item type**, not field number, and explains what "not hashed" means
for `BlockProof`, `BlockFooter`, `FilteredItemHash`, `RedactedItem`, and `RecordFileItem`.

---

### 3. Merkle tree topology — fully specified

The block Merkle tree is now documented as a **depth-5 binary tree with eight fixed
leaves**, with:

- Leaf-index table (0–7) mapping each leaf to its source (`BlockFooter` vs. streaming
  hasher) and its semantic meaning.
- SHA-384 domain-separated prefix rules (`0x00` leaf, `0x01` single-child, `0x02`
  two-child).
- An EVM-compatibility note explaining why `stateRootHash` captures the state at the
  **start** of block N (not the end) and why this requires state proofs for changes
  within block N to reference block N+1's footer.

---

### 4. `TraceData` block item — new section

A dedicated section specifies the `TraceData` item type: its purpose (EVM execution logs,
call traces, gas diagnostics), its hasher assignment (`traceDataHasher`, leaf index 7),
and its optionality (zero or more per block). Includes the protobuf definition.

---

### 5. `FilteredItemHash` — expanded with usage guide

The `FilteredItemHash` section is rewritten to explain the privacy-preserving filtered
stream use case end-to-end: how a filtered stream is produced, how a downstream verifier
can still validate the block proof using only the hash stubs, and how full reconstruction
is possible if the original items are later obtained. Field comments are clarified.

---

### 6. `BlockProof` — three forms now formally specified

`BlockProof` now documents three distinct forms:

| Form | When Used | Mechanism |
|------|-----------|-----------|
| **`TssSignedBlockProof`** | Genesis, cutover, key rotation | Direct TSS-BLS aggregate signature over block root hash |
| **State Proof (WRAPS)** | Steady-state when signature fragments arrive late | Sibling-hash Merkle path from block M's root to a later signed block N |
| **`SignedRecordFileProof`** | Historical wrapped record blocks (see HIP-1427) | RSA signatures over the original record file hash, verified against the address book at time of block |

The `TssSignedBlockProof` message is introduced as a new protobuf message carrying the
aggregate BLS signature bytes. The `BlockProof` protobuf fields are updated: fields 2
and 3 (`previous_block_root_hash`, `start_of_block_state_root_hash`) are marked
`deprecated` as their values are now canonical in `BlockFooter`; field 2 is replaced
with `TssSignedBlockProof signed_block_proof`.

---

### 7. `BlockFooter` — new protobuf definition and section

`BlockFooter` is now a first-class citizen of the specification with its own section and
protobuf definition, explaining each of its three fields and the timing rationale for
`start_of_block_state_root_hash`.

---

### 8. Rejected Ideas — three new entries

Added three new Rejected Ideas entries explaining design decisions:

- **Start-of-block vs. end-of-block state root** — EVM compatibility and performance
  rationale.
- **Two forms of `TssSignedBlockProof`** — why both aggregate-signature and WRAPS
  (chained sibling-hash) forms are needed rather than a single form.
- **Five independent streaming hashers** — rationale for type-separated subtrees over a
  single flat tree.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
