### PR TITLE
Finalize HIP-1137: Block Node discoverabilty via on chain registry (v0.73.0)

### DIFF
--- a/HIP/hip-1137.md
+++ b/HIP/hip-1137.md
@@ -11,10 +11,11 @@ needs-hedera-review: Yes
 hedera-review-date: 2026-02-02
 hedera-acceptance-decision: Accepted
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1137
-status: Approved
+status: Final
+release: v0.73.0
 last-call-date-time: 2026-02-11T07:00:00Z
 created: 2025-03-07
-updated: 2026-04-29
+updated: 2026-05-20
 ---
 
 ## Abstract


### PR DESCRIPTION
## Summary
- Marks HIP-1137 as Final in release v0.73.0

## Test plan
- [ ] CI checks pass (DCO + GitHub Pages build)