### PR TITLE
HIP-1483: New debug and trace APIs on Mirror node side

### DIFF
--- a/HIP/hip-1483.md
+++ b/HIP/hip-1483.md
@@ -13,6 +13,7 @@ hedera-acceptance-decision:
 status: Review
 last-call-date-time: 2026-03-17T07:00:00Z
 created: 2026-05-28
+updated: 2026-06-02
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/1484
 ---
 
@@ -41,9 +42,9 @@ The existing `contracts/call` endpoint in Mirror Node will be enhanced via a `st
 
 `eth_simulatev1` support will be added to the Mirror Node. It will allow users to send a list of transactions as a bundle, part of a block at specific block height. It will allow state overrides as well.
 
-A new tracer `keccak256PreimageTracer` will be added to the current and newly added debug related endpoints. It will capture the keccak256 operations during transaction execution and this will help users map the hashed storage slots back to their original keys/indices.
+A new tracer `keccak256PreimageTracer` will be added to debug_traceTransaction and debug_traceCall related endpoints. It will capture the keccak256 operations during transaction execution and this will help users map the hashed storage slots back to their original keys/indices.
 
-Support for `prestateTracer` will be added. This will increase the compatibility for debug functionality between EVM compatible ledgers and Hiero. This tracer shows the accounts touched during the EVM execution and their pre  and/or post state.
+Support for `prestateTracer` will be added. This will increase the compatibility for debug functionality between EVM compatible ledgers and Hiero. This tracer shows the accounts touched during the EVM execution and their pre and/or post state.
 
 ## User stories
 
@@ -103,7 +104,11 @@ RLP encoded EVM transactions utilize `gasPrice`, `maxFeePerGas`, `maxPriorityFee
 
 #### State Overrides
 
-The existing `/api/v1/contracts/call` REST API in Mirror Node will be enhanced with an optional request field `state_overrides`. The state overrides allow the user to simulate a call as if the state was actually set using the passed values instead of the real ones from the database. Users can override the `address`, `balance`, `code`, `nonce`, and `state`. Here is an example of a request:
+The existing `/api/v1/contracts/call` REST API in Mirror Node will be enhanced with an optional request field `state_overrides`. The state overrides allow the user to simulate a call as if the state was actually set using the passed values instead of the real ones from the database. Users can override the `balance`, `code`, `nonce`, and `state`. 
+
+The `state` can be overridden using `state` and `state_diff` fields. The `state` maps overridden values for all slots in the contract storage, while the `state_diff` maps individual slots. Both fields are not inclusive, only one of them should be used at a time.
+
+Here is an example of a request:
 
 ```json
 {
@@ -133,17 +138,30 @@ The existing `/api/v1/contracts/call` REST API in Mirror Node will be enhanced w
 }
 ```
 
+#### Tracer Config
+
+`debug_traceCall` and `debug_traceCallMany` will have a new nested object called `tracer_config`. It will contain all needed information for the tracing process, including:
+
+1. `code` - if enabled the `prestateTracer` includes information about the contract bytecode
+2. `diff` - if enabled the `prestateTracer` includes `pre` and `post` arrays comparing changes before and after the transaction execution
+3. `memory` - if enabled the `opcodeLogger` includes information about the EVM memory at each executed opcode
+4. `only_top_call` - if enabled the `callTracer` includes information only about the root top level call
+5. `stack` - if enabled `opcodeLogger` includes information about the EVM stack at each executed opcode
+6. `storage` - if enabled `opcodeLogger` or `prestateTracer` include information about the contract storage
+7. `timeout` - if enabled the execution will timeout with `HTTP 408 REQUEST_TIMEOUT` error, so that no more resources are waisted
+8. `tracer` - points the tracer type that should be used for the tracing. This field determines the output populated as a response.
+
+If the request contains mismatched parameters e.g. enabling `diff` with `callTracer` or enabling `storage` with `prestateTracer`, there will be a `400 BAD_REQUEST` response.
+
+
 #### debug_traceCall
 
-`debug_traceCall` simulates a transaction against the state at a specified block and returns a step-by-step execution 
-trace. It accepts an optional tracer (e.g. callTracer, prestateTracer, or a custom JS/Go tracer) to shape the output, 
-making it the standard tool for debugging contract logic, profiling gas, and inspecting internal calls before sending a 
-real transaction. Depending on the `tracer` that was provided as an input parameter to the `debug_traceCall` 
-RPC endpoint, a new Mirror Node endpoint `POST api/v1/contracts/call/debug` will be added. It will accept a different 
-tracer type in its request body.
+`debug_traceCall` simulates a transaction against the state at a specified block and returns a step-by-step execution trace. It accepts an optional tracer (e.g. callTracer, prestateTracer, or a custom JS/Go tracer) to shape the output, 
+making it the standard tool for debugging contract logic, profiling gas, and inspecting internal calls before sending a real transaction. Depending on the `tracer` that was provided as an input parameter to the `debug_traceCall` 
+RPC endpoint, a new Mirror Node endpoint `POST api/v1/contracts/call/debug` will be added. It will accept a different tracer type in its request body.
 
 1. For `debug_traceCall` called with `callTracer` the tracer tracks all message frames invoked in the transaction execution.
-This tracer will have an optional `onlyTopCall` config that limits the response only to information about the root call.
+This tracer will have an optional `only_top_call` config that limits the response only to information about the root call.
 
 Example request body:
     
@@ -156,14 +174,15 @@ Example request body:
     "gas_price": 68000,
     "to": "0x00000000000000000000000000000000000005c1",
     "value": 0,
-    "tracer": "callTracer",
-    "tracerConfig": {
+    "tracer_config": {
         "code": false,
         "diff": false,
         "memory": false,
-        "onlyTopCall": true,
+        "only_top_call": true,
         "stack": false,
-        "storage": false
+        "storage": false,
+        "timeout": "30s",
+        "tracer": "callTracer"
     }
 }
 ```
@@ -217,14 +236,15 @@ Example request body:
 	"gas_price": 68000,
 	"to": "0x00000000000000000000000000000000000005c1",
 	"value": 0,
-	"tracer": "opcodeLogger",
-    "tracerConfig": {
+    "tracer_config": {
         "code": false,
         "diff": false,
         "memory": true,
-        "onlyTopCall": false,
+        "only_top_call": false,
         "stack": true,
-        "storage": true
+        "storage": true,
+        "timeout": "30s",
+        "tracer": "opcodeLogger"
     }
 }
 ```
@@ -280,14 +300,15 @@ Example request body:
 	"gas_price": 68000,
 	"to": "0x00000000000000000000000000000000000005c1",
 	"value": 0,
-	"tracer": "prestateTracer",
-    "tracerConfig": {
+    "tracer_config": {
         "code": false,
         "diff": true,
         "memory": false,
-        "onlyTopCall": false,
+        "only_top_call": false,
         "stack": true,
-        "storage": true
+        "storage": true,
+        "timeout": "30s",
+        "tracer": "prestateTracer"
     }
 }
 ```
@@ -306,14 +327,14 @@ Example response:
 		          "balance": "0x9d4",
 		          "code": "",
 		          "nonce": 840,
-		          "storage": {}
+		          "storage": null
 		      },
 		      {
 			      "address": "0x6d7ac5d23266c9fea12463b877005bef6dea41a7", 
 			      "balance": "0x0",
 		          "code": "0x608060405...",
 		          "nonce": null,
-		          "storage": {}
+		          "storage": null
 		      }   
 		],
 		"post": [
@@ -322,14 +343,14 @@ Example response:
 		        "balance": "0x9d5",
 		        "code": "",
 		        "nonce": 841,
-		        "storage": {}
+		        "storage": null
 		      }
 		]
 	}
 }
 ```
 
-1. For `debug_traceCall` called with `keccak256PreimageTracer`, the tracer will return a list of keccak256 hashes and the original memory slice that was hashed.
+4. For `debug_traceCall` called with `keccak256PreimageTracer`, the tracer will return a list of keccak256 hashes and the original memory slice that was hashed.
 
 An example request body:
 
@@ -343,7 +364,7 @@ An example request body:
 	"to": "0x00000000000000000000000000000000000005c1",
 	"value": 0,
 	"tracer": "keccak256PreimageTracer",
-	"tracerConfig": null
+	"tracer_config": null
 }
 ```
 
@@ -379,7 +400,7 @@ A new endpoint will be defined on mirror node side:
 
 A new requestBody scheme accepting bundles of transactions will be defined.
 
-1. For `debug_traceCallMany` called with `callTracer` the tracer tracks all message frames invoked in the transaction execution. It will return basic information about the top level and its nested calls. This tracer supports additional configuration of boolean `onlyTopCall`, that if set to `true` will return information only for the root top level call, skipping all nested actions.
+1. For `debug_traceCallMany` called with `callTracer` the tracer tracks all message frames invoked in the transaction execution. It will return basic information about the top level and its nested calls. This tracer supports additional configuration of boolean `only_top_call`, that if set to `true` will return information only for the root top level call, skipping all nested actions.
 
 Example request body:
 
@@ -394,26 +415,27 @@ Example request body:
                 }
             ],
             "block_override": {
-            "block_number": "0x100"
+                "number": "0x100",
+                "time": null
             }
         }
     ],
     "block_number": "0x40",
     "transaction_index": -1,
-    "timeout": "30s",
-    "tracer": "callTracer",
-    "tracerConfig": {
+    "tracer_config": {
         "code": false,
         "diff": false,
         "memory": false,
-        "onlyTopCall": true,
+        "only_top_call": true,
         "stack": false,
-        "storage": false
+        "storage": false,
+        "timeout": "30s",
+        "tracer": "callTracer"
     }
 }
 ```
 
-Example response  is:
+Example response is:
 
 ```json
 {
@@ -465,8 +487,8 @@ Example response  is:
             ]
         }
     ],
-    "opcodes": {},
-    "prestate": {}
+    "opcodes": null,
+    "prestate": null
 }
 ```
 
@@ -480,27 +502,29 @@ Example request body is:
         {
             "transactions": [ { "to": "0x...", "data": "0x..." } ],
             "block_override": {
-                "block_number": "0x100"
+                "number": "0x100",
+                "time": null
             }
         },
         {
             "transactions": [ { "to": "0x...", "data": "0x..." } ],
             "block_override": {
-                "block_number": "0x200"
+                "number": "0x200",
+                "time": null
             }
         }
     ],
     "block_number": "0x40",
     "transaction_index": -1,
-	"timeout": "30s",
-	"tracer": "opcodeLogger",
-    "tracerConfig": {
+    "tracer_config": {
         "code": false,
         "diff": false,
         "memory": true,
-        "onlyTopCall": false,
+        "only_top_call": false,
         "stack": true,
-        "storage": true
+        "storage": true,
+        "timeout": "30s",
+        "tracer": "opcodeLogger"
     }
 }
 ```
@@ -612,7 +636,8 @@ Example request body is:
                 }
             ],
             "block_override": {
-                "block_number": "0x100"
+                "number": "0x100",
+                "time": null
             }
         }
     ],
@@ -620,7 +645,7 @@ Example request body is:
     "transaction_index": -1,
     "timeout": "30s",
     "tracer": "prestateTracer",
-    "tracerConfig": null
+    "tracer_config": null
 }
 ```
 
@@ -699,7 +724,7 @@ An example request body sent to the API:
 }
 ```
 
-An example response from the Mirror Node API is:
+An example response is:
 
 ```json
 {
@@ -888,8 +913,6 @@ An example response from a `debug_traceTransaction` using a `keccak256PreimageTr
 
 ```json
 {
-	"actions": null,
-	"opcodes": null,
 	"preimage": [
 	    {
 		    "keccak": "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
@@ -899,8 +922,7 @@ An example response from a `debug_traceTransaction` using a `keccak256PreimageTr
 		    "keccak": "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
 		    "memory": "0x00000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000000"
 	    }
-	],
-	"prestate": null
+	]
 }
 ```
 

--- a/HIP/hip-xxx.md
+++ b/HIP/hip-xxx.md
@@ -1,19 +1,19 @@
 ---
-hip: XXX
+hip: 1483
 title: EVM Debug and Trace APIs
 author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>
 working-group: Steven Sheehy <@steven-sheehy>
 requested-by: 
 type: Standards Track
 category: Mirror
-needs-hiero-approval: No
+needs-hiero-approval: Yes
 needs-hedera-review: Yes
 hedera-review-date: 
 hedera-acceptance-decision: 
-status: Draft
+status: Review
 last-call-date-time: 2026-03-17T07:00:00Z
 created: 2026-05-28
-discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/xxx
+discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/1484
 ---
 
 

--- a/HIP/hip-xxx.md
+++ b/HIP/hip-xxx.md
@@ -1,0 +1,949 @@
+---
+hip: XXX
+title: EVM Debug and Trace APIs
+author: Ivan Kavaldzhiev <ivan.kavaldzhiev@limechain.tech>
+working-group: Steven Sheehy <@steven-sheehy>
+requested-by: 
+type: Standards Track
+category: Mirror
+needs-hiero-approval: No
+needs-hedera-review: Yes
+hedera-review-date: 
+hedera-acceptance-decision: 
+status: Draft
+last-call-date-time: 2026-03-17T07:00:00Z
+created: 2026-05-28
+discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/xxx
+---
+
+
+## Abstract
+
+To enhance the EVM compatibility of the network, additional debug and trace APIs will be added to the Mirror Node and JSON-RPC Relay. Additionally, existing APIs will be enhanced to support additional tracers and options to aid in debugging EVM transactions.
+
+## Motivation
+
+When users encounter an issue with their contract, it is challenging to debug since it is executed on a remote machine outside their control. For this reason, various debug and tracing APIs were added to the JSON-RPC specification to improve the user’s troubleshooting experience. To improve the EVM compatibility related to block support, single call, and multiple calls debugging functionality, we need to perform some changes to the API endpoint definitions on the Mirror Node.
+
+The performance of block related APIs on the JSON-RPC relay can be improved by calculating the `receipts_root` field on ingestion instead of calculating it on demand.
+
+## Rationale
+
+Currently the JSON-RPC Relay is performing intensive calculations to populate the `receipts_root` for block related APIs. It fetches data from multiple mirror-node APIs and iterates over multiple items inside a block to populate the field. This whole calculation will be moved to the Mirror Node importer and calculated during block stream ingestion.
+
+When a transaction is sent to the JSON-RPC Relay via `eth_sendRawTransaction` a special denomination called weibar is used. Currently, when saving EVM transactions, Mirror Node converts weibar to tinybar by dividing by 10 million and thus losing precision for all fields that store their amounts in weibars. As a consequence, it’s impossible for clients to reconstruct the RLP form of the EVM transaction using the data in the REST APIs. This HIP will propose a change to directly store the weibar amounts to unblock such cases. It will expose a new query parameter called `hbar` to enable this new format.
+
+Support for `debug_traceCall` will be added to the Mirror Node REST API. It’s very similar to the existing `debug_traceTransaction` that re-executes a previously executed EVM transaction, with the difference that the transaction simulation will be based on a provided request body within a specific block context. The response will be the same as `debug_traceTransaction` with the support of `callTracer` and `opcodeTracer`, as well as two new tracers - `prestateTracer` and `keccak256PreimageTracer` for providing a different view of the same data set.
+
+`debug_traceCallMany` support will also be added. It will allow tracing a simulation of many transactions simultaneously. It will have the option of overriding block specific context, adding state override, tracer type, and setting a timeout. In this way users can see what traces a bundle of transactions will produce without actually executing them in the network.
+
+The existing `contracts/call` endpoint in Mirror Node will be enhanced via a `state_override` nested object. It will allow users to replace account related fields and/or the bytecode and the state of a contract, without actually modifying the contract itself.
+
+`eth_simulatev1` support will be added to the Mirror Node. It will allow users to send a list of transactions as a bundle, part of a block at specific block height. It will allow state overrides as well.
+
+A new tracer `keccak256PreimageTracer` will be added to the current and newly added debug related endpoints. It will capture the keccak256 operations during transaction execution and this will help users map the hashed storage slots back to their original keys/indices.
+
+Support for `prestateTracer` will be added. This will increase the compatibility for debug functionality between EVM compatible ledgers and Hiero. This tracer shows the accounts touched during the EVM execution and their pre  and/or post state.
+
+## User stories
+
+1. As a relay operator, I want to efficiently read `receipts_root` when using block related APIs without performing costly calculations on the relay for every call.
+2. As a user, I want to be able to retrieve data for executed EVM transactions from Mirror Node APIs and recreate the original RLP encoded format of the transaction by having all numeric values without lost precision.
+3. As a user, I want to see the possible traces that a transaction might produce within a given block using different type of tracers by calling `debug_traceCall`.
+4. As a user, I want to execute an `eth_call` request by overriding contract state, so that I can inspect the impact of such state without actually modifying my contract.
+5. As a user, I want to test a bundle of transactions inside a specific block context via `eth_simulatev1` without actually submitting them to the network.
+6. As a user, I want to inspect the trace of a list of transactions as a bundle using `debug_traceCallMany` without actually submitting them to consensus nodes.
+7. As a user, I want to debug a transaction and track the changed slots back to their original keys/indices using `keccak256preimage` tracer.
+8. As a user, I want to debug a transaction with a `prestateTracer` to see which accounts and contract storage slots are impacted.
+
+## Specification
+
+### Mirror node
+
+#### Receipts Root
+
+A new field called `receipts_root` will be added to all Mirror Node block related APIs. It will directly keep the calculated `receipts_root` field from block stream handling. This will be a very performant and convenient way to populate this field in all block related APIs, including
+`/api/v1/blocks` and `/api/v1/blocks/{hashOrNumber}`. The field will be calculated upon record stream and block stream ingestion by using the following steps:
+
+Here is a pseudo algorithm for the calculation. For each block that is going to be processed:
+
+1. Get the contract results and the logs for all transactions inside the block
+2. Recover transaction objects from the fetched data
+3. Create synthetic transactions from the logs
+4. De-duplicate transactions created from the contract results and from the logs
+5. Iterate over transaction hashes, contract results and logs to create list of receipt root hashes
+6. Calculate the root hash using all receipt roots
+
+An example of `/api/v1/blocks/{hashOrNumber}`  request after the changes:
+
+```jsx
+{
+	"count": 3,
+	"gas_used": 300000,
+	"hapi_version": "0.11.0",
+	"hash": "0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b999fc7e86699f60f2a3fb3ed9a646c6b",
+	"logs_bloom": "0x00000020002000001000000000000000000000000000000000000000000010000000000004000000000000000000000000108000000000000000000080000000000004000000000000000000000000880000000000000000000101000000000000000000000000000000000000008000000000000400000080000000000001000000000000000000000000000000000000000000002000000000100000100000200000040000100000001000000000000000000000000000000001001000004000000000000000000001000000000000000000100000000000100000000000000000000000000000000000000000000000080000100800000000000000120080",
+	"name": "2022-05-03T06_46_26.060890949Z.rcd",
+	"number": 77,
+	"previous_hash": "0xf7d6481f659c866c35391ee230c374f163642ebf13a5e604e04a95a9ca48a298dc2dfa10f51bcbaab8ae23bc6d662a0b",
+	"receipts_root": "0x56e91f271bcc54a6ff8345e692c0f86e5b48e21b936caed001722fb5e363b425"
+	"size": 8192,
+	"timestamp": {
+		"from": "1651560386.060890949",
+		"to": "1651560386.661997287"
+	}
+}
+```
+
+The endpoint `/api/v1/blocks` will be similarly affected.
+
+#### Storing weibars
+
+RLP encoded EVM transactions utilize `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, and `value` amounts in weibar, which have more decimal places than tinybar. In order not to lose precision by converting the weibars into tinybars, these fields will be directly saved in weibar denomination without any conversion. In addition, all contract result REST APIs that return these fields will be enhanced with a boolean `hbar` query parameter. If the value is set to true, then the amount will be converted to tinybars as it was before and if the value is set to false, the saved amount will be directly populated. If the value is omitted, then it will default to true to ensure backwards compatibility with existing clients.
+
+#### State Overrides
+
+The existing `/api/v1/contracts/call` REST API in Mirror Node will be enhanced with an optional request field `state_overrides`. The state overrides allow the user to simulate a call as if the state was actually set using the passed values instead of the real ones from the database. Users can override the `address`, `balance`, `code`, `nonce`, and `state`. Here is an example of a request:
+
+```json
+{
+	"block": "latest",
+	"data": "0x81a73ad500000000000000000000000000000000000000000000000000000000000004e5",
+	"estimate": false,
+	"from": "0x00000000000000000000000000000000000004e2",
+	"gas": 100000000,
+	"gas_price": 100000000,
+	"state_overrides": [
+		{
+            "address": "0x00000000000000000000000000000000000004e4",
+		    "balance": "0xFFFFFFFFFFFFFFFFFFFF",
+		    "code": "0x602a60005260206000f3",
+		    "nonce": "0x1",
+		    "state": [
+			    {
+			      "key": "0x0000000000000000000000000000000000000000000000000000000000000003",
+			      "value": "0x000000000000000000000000000000000000000000000000000000000000370f"
+			    }
+            ],
+		    "state_diff": []
+		}
+	],
+	"to": "0x00000000000000000000000000000000000004e4",
+	"value": 0
+}
+```
+
+#### debug_traceCall
+
+`debug_traceCall` simulates a transaction against the state at a specified block and returns a step-by-step execution 
+trace. It accepts an optional tracer (e.g. callTracer, prestateTracer, or a custom JS/Go tracer) to shape the output, 
+making it the standard tool for debugging contract logic, profiling gas, and inspecting internal calls before sending a 
+real transaction. Depending on the `tracer` that was provided as an input parameter to the `debug_traceCall` 
+RPC endpoint, a new Mirror Node endpoint `POST api/v1/contracts/call/debug` will be added. It will accept a different 
+tracer type in its request body.
+
+1. For `debug_traceCall` called with `callTracer` the tracer tracks all message frames invoked in the transaction execution.
+This tracer will have an optional `onlyTopCall` config that limits the response only to information about the root call.
+
+Example request body:
+    
+```json
+{
+    "block": "latest",
+    "data": "0x81a73ad500000000000000000000000000000000000000000000000000000000000006b2",
+    "from": "0x00000000000000000000000000000000000003d8",
+    "gas": 45000,
+    "gas_price": 68000,
+    "to": "0x00000000000000000000000000000000000005c1",
+    "value": 0,
+    "tracer": "callTracer",
+    "tracerConfig": {
+        "code": false,
+        "diff": false,
+        "memory": false,
+        "onlyTopCall": true,
+        "stack": false,
+        "storage": false
+    }
+}
+```
+    
+    Example response:
+    
+```json
+{
+    "actions": {
+        "calls": [
+            {
+                "error": null,
+                "from": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+                "gas": "0x2ee96d1",
+                "gas_used": "0x9e1",
+                "input": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
+                "output": "0x000000000000000000000000000000000000000000000000000000000026009c",
+                "revert_reason": null,
+                "to": "0xab838fe7d492c621a5b1b23952af99cc37a2e0d3",
+                "type": "DELEGATECALL",
+                "value": "0x0"
+            }
+        ],
+        "error": null,
+        "from": "0x0000000000000000000000000000000000000000",
+        "gas": "0x2faf080",
+        "gas_used": "0x79b6",
+        "input": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "output": "0x000000000000000000000000000000000000000000000000000000000026009c",
+        "revert_reason": null,
+        "to": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+        "type": "CALL",
+        "value": "0x0"
+    },
+    "opcodes": null,
+    "preimage": null,
+    "prestate": null
+}
+```
+
+2. For `debug_traceCall` called with `opcodeLogger`, the tracer will return the existing response schema for a list of opcodes. If no specific tracer is passed in the body, `opcodeLogger` will be used as a default.
+
+Example request body:
+
+```json
+{
+	"block": "latest",
+	"data": "0x81a73ad500000000000000000000000000000000000000000000000000000000000006b2",
+	"from": "0x00000000000000000000000000000000000003d8",
+	"gas": 45000,
+	"gas_price": 68000,
+	"to": "0x00000000000000000000000000000000000005c1",
+	"value": 0,
+	"tracer": "opcodeLogger",
+    "tracerConfig": {
+        "code": false,
+        "diff": false,
+        "memory": true,
+        "onlyTopCall": false,
+        "stack": true,
+        "storage": true
+    }
+}
+```
+
+Example response:
+
+```json
+{
+	"actions": null,
+	"opcodes": {
+	    "address": "0x8fa74f0a79112c8c46c8e6739eb8cc929083298c",
+	    "contract_id": "0.0.1059",
+	    "gas": 24116,
+	    "failed": false,
+	    "return_value": "",
+	    "opcodes": [
+	        {
+	            "depth": 1,
+	            "gas": 4519,
+	            "gas_cost": 100,
+		          "memory": [
+	              "0x0000000000000000000000000000000000000000000000000000000000000000",
+	              "0x0000000000000000000000000000000000000000000000000000000000000000",
+	              "0x0000000000000000000000000000000000000000000000000000000000000080"
+	            ],
+	            "op": "SLOAD",
+	            "pc": 541,
+	            "reason": null,
+	            "stack": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000080"
+                ],
+	            "storage": {
+                    "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000014"
+                }
+	        }
+	    ]
+	},
+	"preimage": null,  
+	"prestate": null
+}
+```
+
+3. For `debug_traceCall` called with `prestateTracer`, the tracer will return a new schema showing the tracking of all accounts and contract storage slots that were touched during the simulation.
+
+Example request body:
+
+```json
+{
+	"block": "latest",
+	"data": "0x81a73ad500000000000000000000000000000000000000000000000000000000000006b2",
+	"from": "0x00000000000000000000000000000000000003d8",
+	"gas": 45000,
+	"gas_price": 68000,
+	"to": "0x00000000000000000000000000000000000005c1",
+	"value": 0,
+	"tracer": "prestateTracer",
+    "tracerConfig": {
+        "code": false,
+        "diff": true,
+        "memory": false,
+        "onlyTopCall": false,
+        "stack": true,
+        "storage": true
+    }
+}
+```
+
+Example response:
+
+```json
+{
+	"actions": null,
+	"opcodes": null,
+	"preimage": null,
+	"prestate": {	
+	    "pre": [
+			  {
+		          "address": "0xd26d9000ec8778ae3257305c9acdd79f16f87857",
+		          "balance": "0x9d4",
+		          "code": "",
+		          "nonce": 840,
+		          "storage": {}
+		      },
+		      {
+			      "address": "0x6d7ac5d23266c9fea12463b877005bef6dea41a7", 
+			      "balance": "0x0",
+		          "code": "0x608060405...",
+		          "nonce": null,
+		          "storage": {}
+		      }   
+		],
+		"post": [
+		    {
+		        "address": "0xd26d9000ec8778ae3257305c9acdd79f16f87857",
+		        "balance": "0x9d5",
+		        "code": "",
+		        "nonce": 841,
+		        "storage": {}
+		      }
+		]
+	}
+}
+```
+
+1. For `debug_traceCall` called with `keccak256PreimageTracer`, the tracer will return a list of keccak256 hashes and the original memory slice that was hashed.
+
+An example request body:
+
+```json
+{
+	"block": "latest",
+	"data": "0x81a73ad500000000000000000000000000000000000000000000000000000000000006b2",
+	"from": "0x00000000000000000000000000000000000003d8",
+	"gas": 45000,
+	"gas_price": 68000,
+	"to": "0x00000000000000000000000000000000000005c1",
+	"value": 0,
+	"tracer": "keccak256PreimageTracer",
+	"tracerConfig": null
+}
+```
+
+An example response::
+
+```json
+{
+	"actions": null,
+	"opcodes": null,
+	"preimage": [
+	    {
+		    "keccak": "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+		    "memory": "0x0000000000000000000000000000000000000000000000000000000000000000"
+		},
+	    {
+		    "keccak": "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
+		    "memory": "0x00000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000000"
+	    }
+	],
+    "prestate": null
+}
+```
+
+#### debug_traceCallMany
+
+A new endpoint will be added in JSON-RPC Relay. It will allow tracing a single or multiple transactions in a specific block context. The list of transactions will be executed using specific block context that is passed under blockOverride plus using a simulation context. Additionally the user can pass stateOverrides object, a predefined timeout limit for running the simulation and a tracer type to be used.
+
+Transactions can be passed in separate bundles, where each bundle has a specific `blockOverride` nested field. It will denote what block number value to be used inside the EVM execution. There is a separate `block_number` value passed for all bundles. It will be used to load the state for the specific block. All calls will be executed against this state. The `transaction_index` will specify what state to use based on a specific transaction index in the block. For example if we have `transaction_index` of 5, we should first execute the first 5 transactions of the specified block by `block_number` and then start simulating the first bundle of transactions. If the provided `transaction_index` is bigger than the total number of transactions in the block, the call will fail with 400 BAD_REQUEST status.
+
+A new endpoint will be defined on mirror node side:
+
+`POST /api/v1/contracts/calls/debug`
+
+A new requestBody scheme accepting bundles of transactions will be defined.
+
+1. For `debug_traceCallMany` called with `callTracer` the tracer tracks all message frames invoked in the transaction execution. It will return basic information about the top level and its nested calls. This tracer supports additional configuration of boolean `onlyTopCall`, that if set to `true` will return information only for the root top level call, skipping all nested actions.
+
+Example request body:
+
+```json
+{
+    "bundles": [
+        {
+            "transactions": [
+                {
+                    "to": "0x...",
+                    "data": "0x..."
+                }
+            ],
+            "block_override": {
+            "block_number": "0x100"
+            }
+        }
+    ],
+    "block_number": "0x40",
+    "transaction_index": -1,
+    "timeout": "30s",
+    "tracer": "callTracer",
+    "tracerConfig": {
+        "code": false,
+        "diff": false,
+        "memory": false,
+        "onlyTopCall": true,
+        "stack": false,
+        "storage": false
+    }
+}
+```
+
+Example response  is:
+
+```json
+{
+    "actions": [
+        {
+            "output": "0x",
+            "state_diff": null,
+            "trace": [
+                {
+                    "action": {
+                        "call_type": "call",
+                        "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+                        "gas": "0x80000000419058f9",
+                        "input": "0x",
+                        "to": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+                        "value": "0x186a0"
+                    }, 
+                    "result": {
+                        "gas_used": "0x0",
+                        "output": "0x"
+                    },
+                    "subtraces": 0,
+                    "trace_address": [],
+                    "type": "call"
+                }
+            ]
+        },
+        {
+            "output": "0x",
+            "state_diff": null,
+            "trace": [
+                {
+                    "action": {
+                        "call_type": "call",
+                        "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+                        "gas": "0x80000000419058f9",
+                        "input": "0x",
+                        "to": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+                        "value": "0x186a0"
+                    },
+                    "result": {
+                        "gas_used": "0x0",
+                        "output": "0x"
+                    },
+                    "subtraces": 0,
+                    "trace_address": [],
+                    "type": "call"
+                }
+            ]
+        }
+    ],
+    "opcodes": {},
+    "prestate": {}
+}
+```
+
+2. For `debug_traceCallMany` called with `opcodesLogger`, the tracer will return the existing response schema for a list of opcodes. If no specific tracer is passed in the body, `opcodeLogger` will be used as a default.
+
+Example request body is:
+
+```json
+{
+    "bundles": [
+        {
+            "transactions": [ { "to": "0x...", "data": "0x..." } ],
+            "block_override": {
+                "block_number": "0x100"
+            }
+        },
+        {
+            "transactions": [ { "to": "0x...", "data": "0x..." } ],
+            "block_override": {
+                "block_number": "0x200"
+            }
+        }
+    ],
+    "block_number": "0x40",
+    "transaction_index": -1,
+	"timeout": "30s",
+	"tracer": "opcodeLogger",
+    "tracerConfig": {
+        "code": false,
+        "diff": false,
+        "memory": true,
+        "onlyTopCall": false,
+        "stack": true,
+        "storage": true
+    }
+}
+```
+
+Example response is:
+
+```json
+{
+    "opcodes":
+	    [
+             {
+	              "address": "0x8fa74f0a79112c8c46c8e6739eb8cc929083298c",
+	              "contract_id": "0.0.1059",
+	              "gas": 24116,
+	              "failed": false,
+	              "return_value": "",
+	              "opcodes": [
+	                {
+	                    "depth": 1,
+                        "gas": 4519,
+	                    "gas_cost": 100,
+		                "memory": [
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+	                        "0x0000000000000000000000000000000000000000000000000000000000000080"
+	                    ],
+	                    "op": "SLOAD",
+	                    "pc": 541,
+	                    "reason": null,
+	                    "stack": [
+                            "0x0000000000000000000000000000000000000000000000000000000000000080"
+                        ],
+	                    "storage": {
+                            "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000014"
+                        }
+                    }
+	              ]
+	          },
+	          {
+	            "address": "0x8fa74f0a79112c8c46c8e6739eb8cc929083298c",
+	            "contract_id": "0.0.1059",
+	            "gas": 24116,
+	            "failed": false,
+	            "return_value": "",
+	            "opcodes": [
+	                {
+	                    "depth": 1,
+	                    "gas": 4519,
+	                    "gas_cost": 100,
+                        "memory": [
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+	                        "0x0000000000000000000000000000000000000000000000000000000000000080"
+	                    ],
+	                    "op": "SLOAD",
+	                    "pc": 541,
+	                    "reason": null,
+	                    "stack": [
+                            "0x0000000000000000000000000000000000000000000000000000000000000080"
+                        ],
+	                    "storage": {
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000014"
+	                    }
+	                }
+	            ]
+	        }, 
+            {
+	            "address": "0x8fa74f0a79112c8c46c8e6739eb8cc929083298c",
+	            "contract_id": "0.0.1059",
+	            "gas": 24116,
+	            "failed": false,
+	            "return_value": "",
+	            "opcodes": [
+	                {
+	                    "depth": 1,
+	                    "gas": 4519,
+                        "gas_cost": 100,
+		                "memory": [
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+	                        "0x0000000000000000000000000000000000000000000000000000000000000080"
+	                    ],
+	                    "op": "SLOAD",
+	                    "pc": 541,
+	                    "reason": null,
+	                    "stack": ["0x0000000000000000000000000000000000000000000000000000000000000080"],
+	                    "storage": {
+	                        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000014"
+	                    }
+                    }
+	            ]
+	        }
+        ]
+}
+```
+
+3. For `debug_traceCallMany` called with `prestateTracer`, the tracer will return tracking of all accounts and contract storage slots that were touched during the simulation.
+
+Example request body is:
+
+```json
+{
+    "bundles": [
+        {
+            "transactions": [
+                {
+                    "to": "0x...",
+                    "data": "0x..."
+                }
+            ],
+            "block_override": {
+                "block_number": "0x100"
+            }
+        }
+    ],
+    "block_number": "0x40",
+    "transaction_index": -1,
+    "timeout": "30s",
+    "tracer": "prestateTracer",
+    "tracerConfig": null
+}
+```
+
+Example response is:
+
+```json
+{
+    "pre": [
+        {
+            "address": "0xd26d9000ec8778ae3257305c9acdd79f16f87857",
+            "balance": "0x9d4",
+            "nonce": 820
+        },
+        {
+            "address": "0x6d7ac5d23266c9fea12463b877005bef6dea41a7",
+            "balance": "0x0",
+            "code": "0x608060405..."
+        },
+        {
+            "address": "0xd46d9000ec1778ae3257305c9aced79f14f87851",
+            "balance": "0x1e4",
+            "nonce": 350
+        },
+        {
+            "address": "0x9d7ac5d23256c9fea12463b877005bef6d2a41a0",
+            "balance": "0x0",
+            "code": "0x608060405..."
+        }
+    ],
+    "post": []
+}
+```
+
+#### eth_simulatev1
+
+A new endpoint will be added in JSON-RPC Relay. It will allow testing multiple transaction in a specific block context and expecting their output.
+
+The list of transactions will be executed using the block context that is passed. If the `validation` property is set to `true` the transactions will be validated as if they are executed inside a real EVM. The only exception is validating whether the transaction sender is an EOA or a smart contract and the sender signature. If the `traceTransfers` property is set to `true`, all transferred values in tinybars will be captured by emitting ERC20 transfer event logs. The emitter contract will be `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` and this allow tracking internal transfers.
+
+A new `POST /api/v1/contracts/simulate` endpoint will be defined. It will have a new requestBody scheme which will reuse the `StateOverrides` scheme mentioned above.
+
+An example request body sent to the API:
+
+```json
+{
+	"block": "latest",
+	"block_state_calls": [
+		{
+			"calls": [
+				{
+					"from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+					"max_fee_per_gas": "0xf",
+				    "to": "0x014d023e954bAae7F21E56ed8a5d81b12902684D",
+				    "value": "0x1"
+				}
+			],
+			"state_overrides": [ 
+				{
+				 	"address": "0x00000000000000000000000000000000000004e4",
+					"balance": "0xFFFFFFFFFFFFFFFFFFFF",
+				    "code": "0x602a60005260206000f3",
+				    "nonce": "0x1",
+				    "state": [],
+				    "state_diff": [
+					    {
+					        "key": "0x0000000000000000000000000000000000000000000000000000000000000002",
+					        "value": "0x000000000000000000000000000000000000000000000000000000000000270f"
+					    }
+                    ]
+			    }
+			]
+		 }
+	],
+	"trace_transfers": true,
+	"validation": true
+}
+```
+
+An example response from the Mirror Node API is:
+
+```json
+{
+    "result": [
+        {
+            "gas_used": "0x5208",
+            "logs": [
+                {
+                    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "block_hash": "0x5e28f54a56dc9df973a058cd54b3eeef8c67a1a613cb5db1df8a0a434c931d56",
+                    "block_number": "0x13d2747",
+                    "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "log_index": "0x0",
+                    "removed": false,
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x000000000000000000000000c000000000000000000000000000000000000000",
+                        "0x000000000000000000000000c000000000000000000000000000000000000001"
+                    ],
+                    "transaction_hash": "0xe7217784e0c3f7b35d39303b1165046e9b7e8af9b9cf80d5d5f96c3163de8f51",
+                    "transaction_index": "0x0"
+                }
+            ],
+            "return_data": "0x",
+            "status": "0x1"
+        },
+        {
+            "gas_used": "0x5208",
+            "logs": [
+                {
+                    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "block_hash": "0x5e28f54a56dc9df973a058cd54b3eeef8c67a1a613cb5db1df8a0a434c931d56",
+                    "block_number": "0x13d2747",
+                    "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "log_index": "0x1",
+                    "removed": false,
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x000000000000000000000000c000000000000000000000000000000000000000",
+                        "0x000000000000000000000000c000000000000000000000000000000000000002"
+                    ],
+                    "transaction_hash": "0xf0182201606ec03701ba3a07d965fabdb4b7d06b424f226ea7ec3581802fc6fa",
+                    "transaction_index": "0x1"
+                }
+            ],
+            "return_data": "0x",
+            "status": "0x1"
+        },
+        {
+            "gas_used": "0x5208",
+            "logs": [
+                {
+                    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "block_hash": "0x5e28f54a56dc9df973a058cd54b3eeef8c67a1a613cb5db1df8a0a434c931d56",
+                    "block_number": "0x13d2747",
+                    "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "log_index": "0x1",
+                    "removed": false,
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x000000000000000000000000c000000000000000000000000000000000000000",
+                        "0x000000000000000000000000c000000000000000000000000000000000000002"
+                    ],
+                    "transaction_hash": "0xf0182201606ec03701ba3a07d965fabdb4b7d06b424f226ea7ec3581802fc6fa",
+                    "transaction_index": "0x1"
+                }
+            ],
+            "return_data": "0x",
+            "status": "0x1"
+      }
+    ]
+}
+```
+
+The JSON-RPC Relay will consume this response and combine it with a call to a `eth_getBlockByHash` or `eth_getBlockByNumber` using the passed block from the request.
+
+#### Prestate Tracer
+
+A new tracer called `prestateTracer` will be added that tracks the accounts that have been touched during call simulation. It has two different modes: `diff` and `prestate`. `prestate` shows the accounts and part of their information without any changes or updates. This means the tracer will represent the touched accounts state before the execution. If the `diff` mode is used it will show the difference between pre-execution and post-execution. Any updated fields or created/deleted accounts can be analyzed via comparing the two arrays. The `post` array will include only account/contract fields that has changed. If a fields has not changed it will be absent or null.
+
+Since the `debug_traceTransaction` utilizes the `GET /api/v1/contracts/results/{transactionIdOrHash}/opcodes` endpoint, which is scoped to tracking opcodes only, there will be a new endpoint for supporting the `prestateTracer`. It will be `GET /api/v1/contracts/results/{transactionIdOrHash}/prestate` , which will accept several query parameters - `diff`, `code`, `storage`. If the `diff` is set to `true`, the endpoint will return two different arrays - `pre` and `post` for account traces before and after the transaction execution. If the `diff` is set to `false`, only the `pre` array will be populated with account traces using the state before the transaction execution. If `code` is set to `true`, the `code` field will be populated if we have a contract. The same applies for `storage`.
+
+An example request and response in `prestate` mode:
+
+`GET /api/v1/contracts/results/0xe044554a0a55067caafd07f8020ab9f2af60bdfe337e395ecd84b4877a3d1ab4/prestate?code=true&&storage=true`
+
+```json
+{
+    "pre": [
+        {
+            "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+            "balance": "0x0",
+            "code": "",
+            "nonce": 3,
+            "storage": null
+        },
+        {
+            "address": "0xe1dA6BF26964aF9D7eEd9e03E93415D37aA96090",
+            "balance": "0x18",
+            "code": "0x6080...",
+            "nonce": 5,
+            "storage": {
+                "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000024",
+                "0x000000000000000000000000000000000000000000000000000000000000000d": "0x0000000000000000000000000000000000000000000000000000000000000037",
+                "0x00000000000000000000000000000000000000000000000000000000000000a4": "0x0x00000000000000000000000000000000000000000000000000000000000000b8"
+            }
+        },
+        {
+            "address": "0xa6dA6BF26964aF4D7eEd9e03E93415D37aA86006",
+            "balance": "0x1E5AF",
+            "code": "",
+            "nonce": 0,
+            "storage": null
+        }
+    ],
+    "post": []
+}
+```
+
+An example request and response in `diff` mode:
+
+`GET /api/v1/contracts/results/0xe044554a0a55067caafd07f8020ab9f2af60bdfe337e395ecd84b4877a3d1ab4/prestate?diff=true&&code=true&&storage=true`
+
+```json
+{
+    "pre": [
+          {
+              "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+              "balance": "0x0",
+              "code": "",
+              "nonce": 3,
+              "storage": null
+          },
+          {
+              "address": "0xe1dA6BF26964aF9D7eEd9e03E93415D37aA96090",
+              "balance": "0x18",
+              "code": "0x6080...",
+              "nonce": 5,
+              "storage": {
+                  "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000024",
+                  "0x000000000000000000000000000000000000000000000000000000000000000d": "0x0000000000000000000000000000000000000000000000000000000000000037",
+                  "0x00000000000000000000000000000000000000000000000000000000000000a4": "0x0x00000000000000000000000000000000000000000000000000000000000000b8"
+              }
+          }
+      ],
+      "post": [
+          {
+              "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+              "balance": "0x20",
+              "code": "",
+              "nonce": 4,
+              "storage": null
+          },
+          {
+              "address": "0xe1dA6BF26964aF9D7eEd9e03E93415D37aA96090",
+              "balance": "0x18",
+              "code": "0x6080...",
+              "nonce": 6,
+              "storage": {
+                  "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000024",
+                  "0x000000000000000000000000000000000000000000000000000000000000000d": "0x0000000000000000000000000000000000000000000000000000000000000037",
+                  "0x00000000000000000000000000000000000000000000000000000000000000a4": "0x0x00000000000000000000000000000000000000000000000000000000000000b8"
+              }
+          },
+          {
+              "address": "0x18dA6BF27964aF9D7eEd9e03d53415D47aA96081",
+              "balance": "0x0",
+              "code": "0x6080...",
+              "nonce": 0,
+              "storage": null
+          }
+      ]
+}
+```
+
+#### **Keccak256 Preimage Tracer**
+
+The Ethereum ecosystem was enhanced with an additional tracer called `keccak256PreimageTracer`.
+
+During EVM execution the KECCAK256 opcode creates a 32-byte Keccak-256 hash on a slice of the memory. This is a one-way operation and the users can’t discover which memory value produced the specific hash. The keccak256 preimage tracer provides a mapping between a keccak hashed value and the preimage (the memory slice that was hashed).
+
+This tracer will be supported by `debug_traceTransaction` and `debug_traceCall`. Similarly to `prestateTracer`, a new endpoint will be defined for handling `keccak256PreimageTracer`
+for `debug_traceTransaction`. It will be `GET /api/v1/contracts/results/{transactionIdOrHash}/keccak256` .
+
+An example response from a `debug_traceTransaction` using a `keccak256PreimageTracer` is:
+
+```json
+{
+	"actions": null,
+	"opcodes": null,
+	"preimage": [
+	    {
+		    "keccak": "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+		    "memory": "0x0000000000000000000000000000000000000000000000000000000000000000"
+		},
+	    {
+		    "keccak": "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
+		    "memory": "0x00000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000000"
+	    }
+	],
+	"prestate": null
+}
+```
+
+### JSON-RPC Relay
+
+The JSON-RPC Relay will also add support for all the new features being added to the mirror node. As the relay follows the JSON-RPC specification closely, the request and response details for each new or modified RPC will not be repeated here. The reference section contains links to the applicable APIs the relay will implement.
+
+## Backward Compatibility
+
+The new APIs this HIP introduces does not affect backwards compatibility. Block related APIs will be extended with a new field, which also doesn’t affect backward compatibility. The `/ap1/v1/contracts/call` endpoint will have an extended request body, so all consequent calls should utilize it.
+
+## Security Implications
+
+The `debug_traceCall` response can include a large amount of data, so allowing many calls per second for this API might increase the latency of the Mirror Node.
+
+The `eth_simulateV1` call can include up to 16 nested calls to be simulated, so even a single request can introduce a lot of heavy database queries. A separate rate limiter can be implemented for this endpoint, which can be 16 times smaller than the rate for `eth_call` and `eth_estimateGas`.
+
+The `debug_traceCallMany` endpoint will be the heaviest of all newly added APIs. It will trace multiple transactions at once and provide even a bigger output size.
+
+## How to Teach This
+
+Respective documentation will be added.
+
+## References
+
+https://hips.hedera.com/hip/hip-801
+
+https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth
+
+https://www.quicknode.com/docs/soneium/eth_simulateV1
+
+https://www.quicknode.com/docs/ethereum/trace_callMany
+
+https://www.chainnodes.org/docs/base/debug_traceCallMany
+
+https://github.com/ethereum/go-ethereum/pull/32569
+
+https://docs.linea.build/api/reference/debug-tracecall
+
+## Open Issues
+
+None.
+
+## Copyright/license
+
+This document is licensed under the Apache License, Version 2.0 -- see [LICENSE](../LICENSE) or (https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
**Description**:
Add a HIP definition for some new debug and trace APIs that are going to be added on mirror-node side. In addition some new tracers - prestateTracer and keccak256PreimageTracer will be added to the existing debug endpoint and the newly added debug_traceCall.

Some performance and compatibility optimisations will be added as well:

- the receipts_root field will be now calculated directly on ingestion, instead of being manually calculated on JSON-RPC relay side
- all weibar values used in Ethereum transactions will be saved directly to DB, without conversion to tinybars, so that they don't loose precision.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
