### PR TITLE
chore: reconcile HIP statuses

### DIFF
--- a/HIP/hip-1137.md
+++ b/HIP/hip-1137.md
@@ -11,11 +11,11 @@ needs-hedera-review: Yes
 hedera-review-date: 2026-02-02
 hedera-acceptance-decision: Accepted
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1137
-status: Final
+status: Approved
 release: v0.73.0
 last-call-date-time: 2026-02-11T07:00:00Z
 created: 2025-03-07
-updated: 2026-06-08
+updated: 2026-06-23
 ---
 
 ## Abstract

--- a/HIP/hip-1261.md
+++ b/HIP/hip-1261.md
@@ -8,7 +8,7 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Final
+status: Approved
 release: v0.73.0
 last-call-date-time: 2025-08-26T07:00:00Z
 hedera-review-date: 2025-08-19
@@ -16,7 +16,7 @@ hedera-acceptance-decision: Accepted
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1261
 requires: 1259
 created: 2025-07-02
-updated: 2026-05-20
+updated: 2026-06-23
 ---
 
 # Abstract

--- a/HIP/hip-1313.md
+++ b/HIP/hip-1313.md
@@ -7,14 +7,14 @@ category: Core
 requested-by: Hashgraph
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1313
 needs-hiero-approval: Yes
-status: Final
+status: Approved
 release: v0.73.0
 needs-hedera-review: Yes
 hedera-reviewed-date: 2025-12-16
 hedera-acceptance-decision: Accepted
 last-call-date-time: 2025-12-30T07:00:00Z
 created: 2025-10-17
-updated: 2026-05-20
+updated: 2026-06-23
 requires: 1261
 ---
 

--- a/HIP/hip-415.md
+++ b/HIP/hip-415.md
@@ -6,13 +6,13 @@ working-group: Danno Ferrin <@shemnon>, Richard Bair <@rbair23>, Mitchell Martin
 type: Standards Track
 category: Core
 needs-council-approval: Yes
-status: Final
+status: Approved
 release: v0.26.0
 created: 2022-03-28
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/434
 last-call-date-time: 2022-05-17T07:00:00Z
 requires: 435
-updated: 2023-02-01
+updated: 2026-06-23
 ---
 
 ## Abstract

--- a/HIP/hip-540.md
+++ b/HIP/hip-540.md
@@ -7,12 +7,12 @@ requested-by: Hedera
 type: Standards Track
 category: Service
 needs-council-approval: Yes
-status: Final
+status: Deferred
 release: 0.50.1
 last-call-date-time: 2023-07-03T07:00:00Z
 created: 2022-08-05
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/discussions/522
-updated: 2024-06-24
+updated: 2026-06-23
 ---
 
 ## Abstract


### PR DESCRIPTION
Reconciles HIP status front matter with the GitHub Projects board.

Project: https://github.com/orgs/hiero-ledger/projects/31/views/1

| HIP | Current status | Board status |
| --- | --- | --- |
| HIP-415 | Final | Approved |
| HIP-540 | Final | Deferred |
| HIP-1137 | Final | Approved |
| HIP-1261 | Final | Approved |
| HIP-1313 | Final | Approved |

The commit was created with DCO sign-off and signed using `git commit -S -s`.
