### PR TITLE
chore: reconcile HIP statuses

### DIFF
--- a/HIP/hip-1261.md
+++ b/HIP/hip-1261.md
@@ -8,7 +8,7 @@ type: Standards Track
 category: Core
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Final
+status: Approved
 release: v0.73.0
 last-call-date-time: 2025-08-26T07:00:00Z
 hedera-review-date: 2025-08-19
@@ -16,7 +16,7 @@ hedera-acceptance-decision: Accepted
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1261
 requires: 1259
 created: 2025-07-02
-updated: 2026-05-20
+updated: 2026-06-23
 ---
 
 # Abstract

--- a/HIP/hip-1313.md
+++ b/HIP/hip-1313.md
@@ -7,14 +7,14 @@ category: Core
 requested-by: Hashgraph
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1313
 needs-hiero-approval: Yes
-status: Final
+status: Approved
 release: v0.73.0
 needs-hedera-review: Yes
 hedera-reviewed-date: 2025-12-16
 hedera-acceptance-decision: Accepted
 last-call-date-time: 2025-12-30T07:00:00Z
 created: 2025-10-17
-updated: 2026-05-20
+updated: 2026-06-23
 requires: 1261
 ---
 

--- a/HIP/hip-1357.md
+++ b/HIP/hip-1357.md
@@ -11,11 +11,11 @@ needs-hiero-approval: Yes
 needs-hedera-review: Yes
 hedera-review-date: 2026-02-02
 hedera-acceptance-decision: Accepted
-status: Final
+status: Approved
 release: v0.73.0
 last-call-date-time: 2026-02-11T07:00:00Z
 created: 2025-12-02
-updated: 2026-05-20
+updated: 2026-06-23
 requires: 1056, 1086, 1137
 ---
 


### PR DESCRIPTION
Reconciles HIP status front matter with the GitHub Projects board.

Project: https://github.com/orgs/hiero-ledger/projects/31/views/1

| HIP | Current status | Board status | Project source |
| --- | --- | --- | --- |
| HIP-1261 | Final | Approved | #1261 |
| HIP-1313 | Final | Approved | #1313 |
| HIP-1357 | Final | Approved | #1357 |

The commit was created with DCO sign-off and signed using `git commit -S -s`.
