### PR TITLE
Fix draft HIP number placeholders

### DIFF
--- a/.github/workflows/add-hip-number.yml
+++ b/.github/workflows/add-hip-number.yml
@@ -52,7 +52,7 @@ jobs:
 
           # Directory path to check for HIP files
           HIP_DIRECTORY='HIP'
-          HIP_FILES=$(echo "$MODIFIED_FILES" | grep "^$HIP_DIRECTORY/.*\.md")
+          HIP_FILES=$(echo "$MODIFIED_FILES" | grep "^$HIP_DIRECTORY/.*\.md" || true)
           echo "Filtered HIP files: $HIP_FILES"
           echo "::set-output name=hip-files::$HIP_FILES"
 

--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -68,6 +68,24 @@ function extractHip(data, content, extra = {}) {
   };
 }
 
+function parsePositiveInteger(value) {
+  if (value === null || value === undefined) return null;
+
+  const normalized = String(value).trim().replace(/^['"]|['"]$/g, '');
+  if (!/^\d+$/.test(normalized)) return null;
+
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function draftHipNumber(frontmatterHip, prNumber, filePath) {
+  const frontmatterNumber = parsePositiveInteger(frontmatterHip);
+  if (frontmatterNumber) return frontmatterNumber;
+
+  const fileNumber = parsePositiveInteger(filePath.match(/^HIP\/hip-(\d+)(?:-[^/]*)?\.md$/i)?.[1]);
+  return fileNumber || prNumber;
+}
+
 // ---- Parse merged HIPs from the HIP/ directory ----
 // ---- ASCII state diagrams to replace broken image references ----
 // For merged HIPs, assets are copied into public/assets/ so we rewrite ../assets/ → /assets/.
@@ -161,8 +179,9 @@ async function fetchDraftHips() {
         continue;
       }
 
-      // Use the PR number as the HIP number if frontmatter doesn't have one
-      const hipNum = parsed.data.hip || pr.number;
+      // Draft PRs often retain placeholder frontmatter such as "hip: xxxx" or
+      // "hip: <to be assigned>". Ignore those and use the assigned draft number.
+      const hipNum = draftHipNumber(parsed.data.hip, pr.number, filePath);
 
       // Force status to Draft if not already set or if it differs
       const data = {


### PR DESCRIPTION
## Summary
- Ignore placeholder draft HIP frontmatter like `xxxx`, `0000`, and `<to be assigned>` when building site data.
- Resolve draft HIP numbers from valid numeric frontmatter, numeric draft file names, or the PR number fallback.
- Let the HIP-number assignment workflow pass through non-HIP-file PRs instead of failing on an empty `grep` result.

## Verification
- `node --check site/scripts/build-data.js`
- `npm run build:data`
- `npm run build`
- Local shell check for the `add-hip-number.yml` no-HIP-file and HIP-file paths
- Confirmed generated draft entries resolve as numeric HIP IDs and no placeholder HIP IDs remain in generated site data.

DCO: both commits include `Signed-off-by`.
GPG: both commits are signed and local verification reports good signatures.