### PR TITLE
chore: reconcile HIP-1331 status

### DIFF
--- a/HIP/hip-1331.md
+++ b/HIP/hip-1331.md
@@ -7,12 +7,11 @@ type: Standards Track
 category: Service
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Last Call
-last-call-date-time: 2026-04-01T07:00:00Z
+status: Review
 discussions-to: https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1331
 requires: 1261
 created: 2025-11-06
-updated: 2026-03-18
+updated: 2026-06-23
 ---
 
 ## Abstract


### PR DESCRIPTION
Reconciles HIP status front matter with the GitHub Projects board.

Project: https://github.com/orgs/hiero-ledger/projects/31/views/1

| HIP | Current status | Board status | Project source |
| --- | --- | --- | --- |
| HIP-1331 | Last Call | Review | #1331 |

The commit was created with DCO sign-off and signed using `git commit -S -s`.
