### PR TITLE
chore: make HIP rename step idempotent

### DIFF
--- a/.github/workflows/add-hip-number.yml
+++ b/.github/workflows/add-hip-number.yml
@@ -52,7 +52,10 @@ jobs:
 
           # Directory path to check for HIP files
           HIP_DIRECTORY='HIP'
-          HIP_FILES=$(echo "$MODIFIED_FILES" | grep "^$HIP_DIRECTORY/.*\.md")
+          # `|| true` so a no-match grep (PRs that touch no HIP files) yields an
+          # empty result instead of exiting non-zero and aborting the step under
+          # `set -eo pipefail`; the empty case is handled gracefully below.
+          HIP_FILES=$(echo "$MODIFIED_FILES" | grep "^$HIP_DIRECTORY/.*\.md" || true)
           echo "Filtered HIP files: $HIP_FILES"
           echo "::set-output name=hip-files::$HIP_FILES"
 

--- a/.github/workflows/add-hip-number.yml
+++ b/.github/workflows/add-hip-number.yml
@@ -104,13 +104,21 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number }}
           HIP_FILE=$(echo "${{ steps.check-new.outputs.hip-files }}" | head -n 1)
 
-          if [ -n "$HIP_FILE" ]; then
-            NEW_HIP_FILE="HIP/hip-$PR_NUMBER.md"
-            mv "$HIP_FILE" "$NEW_HIP_FILE"
-          else
+          if [ -z "$HIP_FILE" ]; then
             echo "No HIP file found to rename. Skipping rename."
             exit 0
           fi
+
+          NEW_HIP_FILE="HIP/hip-$PR_NUMBER.md"
+
+          # Skip the rename when the file is already correctly named; otherwise
+          # `mv <same> <same>` exits non-zero and aborts the remaining steps.
+          if [ "$HIP_FILE" = "$NEW_HIP_FILE" ]; then
+            echo "HIP file already has expected name ($NEW_HIP_FILE). Skipping rename."
+            exit 0
+          fi
+
+          mv "$HIP_FILE" "$NEW_HIP_FILE"
 
       - name: Commit Changes
         if: steps.check-new.outputs.new-hip == 'true'


### PR DESCRIPTION
## Problem

The `Assign HIP Number and Rename File` workflow (`.github/workflows/add-hip-number.yml`) fails on its **Rename HIP File** step when a new HIP's file is already named to match the PR number.

Observed in PR #1494:

```
mv: 'HIP/hip-1494.md' and 'HIP/hip-1494.md' are the same file
```

## Root cause

When the author already names the file `HIP/hip-<PR>.md`, the rename step computes `NEW_HIP_FILE="HIP/hip-$PR_NUMBER.md"`, which is identical to the source. `mv <same> <same>` exits non-zero.

## Impact

Not purely cosmetic. `continue-on-error: true` is set at the **job** level, so the *run* doesn't go red — but a failed step still **skips subsequent steps**, so the **Commit Changes** step never executes after `mv` fails.

## Fix

Make the rename step idempotent: skip `mv` when source and destination are equal (the no-HIP-file early-exit is preserved). The existing `Assign HIP Number` `sed` is already idempotent and `Commit Changes` already no-ops on an empty diff, so no other guards are needed.

> Note: issues are disabled on this repo, so this PR doubles as the bug report.
