### PR TITLE
ci: harden GitHub Actions for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/add-hip-number.yml
+++ b/.github/workflows/add-hip-number.yml
@@ -9,10 +9,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  issues: read
-  pull-requests: write
-  checks: write
+  contents: read
 
 jobs:
   assign-hip-number:
@@ -82,11 +79,12 @@ jobs:
 
       - name: Assign HIP Number
         if: steps.check-new.outputs.new-hip == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HIP_FILES: ${{ steps.check-new.outputs.hip-files }}
         run: |
-          # Extract the current PR number
-          PR_NUMBER=${{ github.event.pull_request.number }}
           HIP_HEADER="hip: $PR_NUMBER"
-          HIP_FILE=$(echo "${{ steps.check-new.outputs.hip-files }}" | head -n 1)
+          HIP_FILE=$(echo "$HIP_FILES" | head -n 1)
 
           echo "Assigning HIP number to file: $HIP_FILE"
 
@@ -99,10 +97,11 @@ jobs:
 
       - name: Rename HIP File
         if: steps.check-new.outputs.new-hip == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HIP_FILES: ${{ steps.check-new.outputs.hip-files }}
         run: |
-          # Extract PR number
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          HIP_FILE=$(echo "${{ steps.check-new.outputs.hip-files }}" | head -n 1)
+          HIP_FILE=$(echo "$HIP_FILES" | head -n 1)
 
           if [ -z "$HIP_FILE" ]; then
             echo "No HIP file found to rename. Skipping rename."
@@ -122,11 +121,13 @@ jobs:
 
       - name: Commit Changes
         if: steps.check-new.outputs.new-hip == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
 
-          PR_NUMBER=${{ github.event.pull_request.number }}
           git add HIP/
 
           # Check if there are changes to commit
@@ -140,7 +141,7 @@ jobs:
             exit 0
           }
 
-          git push origin HEAD:${{ github.head_ref }} || {
+          git push origin "HEAD:$HEAD_REF" || {
             echo "Push failed. This is expected for PRs from forks without write access."
             echo "The PR author will need to manually update their branch."
             exit 0

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,7 +1,6 @@
 name: Dispatch Status Change Notifications (discord and email)
 permissions:
-    contents: read
-    actions: write
+  contents: read
 on:
   push:
     branches:
@@ -13,6 +12,9 @@ defaults:
 jobs:
   DispatchNotifications:
     runs-on: hiero-improvement-proposals-linux-medium
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/schedule-last-call-date-end.yml
+++ b/.github/workflows/schedule-last-call-date-end.yml
@@ -1,9 +1,7 @@
 name: Schedule Status Update Based on Last Call Time
 
 permissions:
-  pull-requests: write
-  contents: write
-  packages: write
+  contents: read
 
 defaults:
   run:
@@ -19,6 +17,9 @@ jobs:
   check-merged-file:
     if: github.event.pull_request.merged == true
     runs-on: hiero-improvement-proposals-linux-medium
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/send-discord-message.yml
+++ b/.github/workflows/send-discord-message.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 defaults:
   run:

--- a/.github/workflows/update-draft-hips.yml
+++ b/.github/workflows/update-draft-hips.yml
@@ -13,8 +13,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }} # Only run on main branch
     runs-on: hiero-improvement-proposals-linux-medium
     permissions:
-      contents: write
-      pull-requests: read
+      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## What

Hardens the repo's GitHub Actions to raise the **OpenSSF Scorecard** score, currently **5.0/10** ([viewer](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-improvement-proposals)). This fixes the two checks scoring **0**.

### Token-Permissions (expect 0 → 10)
Every workflow now declares top-level `permissions: contents: read` and elevates write access only at the job level where the default `GITHUB_TOKEN` is actually used. Unused scopes removed.

| Workflow | Before | After |
|---|---|---|
| `add-hip-number.yml` | top: contents/pull-requests/checks: write, issues: read | top: `contents: read` |
| `update-draft-hips.yml` | job: contents: write, pull-requests: read | job: `contents: read` |
| `notifications.yml` | top: actions: write | top: `contents: read`; `actions: write` moved to job |
| `schedule-last-call-date-end.yml` | top: pull-requests/contents/packages: write | top: `contents: read`; contents/pull-requests: write at job; **packages: write dropped** |
| `send-discord-message.yml` | contents: read + actions: write | `actions: write` dropped (unused) |

### Dangerous-Workflow (expect 0 → 10)
`add-hip-number.yml` interpolated `${{ github.head_ref }}` (and the PR-filename-derived `hip-files` output) directly into `run:` shell — a script-injection sink Scorecard flagged at the `git push` step. These now pass through `env:` and are referenced as quoted shell variables.

## No functional change
- Pushes in `add-hip-number.yml` and `update-draft-hips.yml` authenticate with the `GH_ACCESS_TOKEN` PAT, **not** `GITHUB_TOKEN`, so reducing default-token scopes does not affect them.
- `notifications.yml` (`gh workflow run`) and `schedule-last-call-date-end.yml` (`git push` + `gh pr create/merge`) keep the writes they use — only moved to job scope.
- No trigger or logic changes; all five files YAML-validated.

## Remaining Scorecard gaps (need repo admin — out of scope for this PR)
- **Branch-Protection (4):** enable *Do not allow bypassing the above settings*, *Require branches up to date*, *Require approval of most recent push*; raise required approvals 1 → 2.
- **Code-Review (3):** bots push directly to `main` (e.g. `Update draft HIPs data [skip ci]`); route automated commits through reviewed PRs.
- **SAST (6):** CodeQL default setup misses those direct-to-`main` commits — same root cause.
- **CII-Best-Practices (2):** complete the bestpractices.dev questionnaire (currently *InProgress*).
- **Fuzzing (0):** N/A for a docs repo; caps the ceiling near 9.3.

Ref: [OpenSSF Scorecard checks](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
