### PR TITLE
ci: fetch draft HIPs live at build time (stop bot pushes to main)

### DIFF
--- a/.github/workflows/update-draft-hips.yml
+++ b/.github/workflows/update-draft-hips.yml
@@ -1,174 +1,36 @@
-name: Update Draft HIPs Data
+name: Refresh Draft HIPs on Site
+
+# Draft HIPs (open PRs that add a new HIP) are fetched live during the site
+# build (see site/scripts/build-data.js). This job just triggers a Netlify
+# rebuild on a schedule so the published site stays current, WITHOUT committing
+# any generated data to main. Requires a NETLIFY_BUILD_HOOK repo secret; if it
+# is not set, the job is a no-op.
 
 on:
   schedule:
-    - cron: "0 */6 * * *" # Runs every 6 hours
-  workflow_dispatch: # Allows manual triggering
+    - cron: "0 */6 * * *" # every 6 hours
+  workflow_dispatch: # allow manual triggering
 
 permissions:
   contents: read
 
 jobs:
-  update-draft-hips:
-    if: ${{ github.ref == 'refs/heads/main' }} # Only run on main branch
+  trigger-site-rebuild:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: hiero-improvement-proposals-linux-medium
-    permissions:
-      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - name: Checkout Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          ref: 'main'
-
-      - name: Import GPG Key
-        id: gpg_importer
-        uses: step-security/ghaction-import-gpg@69c854a83c7f79463f8bdf46772ab09826c560cd # v6.3.1
-        with:
-          git_commit_gpgsign: true
-          git_tag_gpgsign: true
-          git_user_signingkey: true
-          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "20"
-
-      - name: Create Script
-        run: |
-          mkdir -p _data
-          cat << 'EOF' > fetch-draft-hips.js
-          const https = require('https');
-          const fs = require('fs');
-
-          async function makeGraphQLRequest(query, token) {
-            return new Promise((resolve, reject) => {
-              const options = {
-                hostname: 'api.github.com',
-                path: '/graphql',
-                method: 'POST',
-                headers: {
-                  'Authorization': `Bearer ${token}`,
-                  'Content-Type': 'application/json',
-                  'User-Agent': 'Node.js'
-                }
-              };
-
-              const req = https.request(options, (res) => {
-                let data = '';
-                res.on('data', chunk => { data += chunk; });
-                res.on('end', () => resolve(JSON.parse(data)));
-              });
-
-              req.on('error', reject);
-              req.write(JSON.stringify({ query }));
-              req.end();
-            });
-          }
-
-          async function getAllPRs() {
-            const query = `
-              query { 
-                repository(name: "hiero-improvement-proposals", owner: "hiero-ledger") {
-                  pullRequests(first: 100, states: [OPEN], orderBy: {field: CREATED_AT, direction: DESC}) {
-                    nodes {
-                      title
-                      number
-                      url
-                      headRefOid
-                      files(first: 100) {
-                        edges {
-                          node {
-                            path
-                            changeType
-                            additions
-                            deletions
-                          }
-                        }
-                      }
-                      author {
-                        login
-                      }
-                    }
-                  }
-                }
-              }
-            `;
-
-            try {
-              const result = await makeGraphQLRequest(query, process.env.GITHUB_TOKEN);
-              
-              if (result.errors) {
-                console.error('GraphQL errors:', result.errors);
-                process.exit(1); 
-              }
-
-              // Check if data and the expected path to nodes exist
-              if (!result.data || !result.data.repository || !result.data.repository.pullRequests || !result.data.repository.pullRequests.nodes) {
-                console.error('Unexpected GraphQL response structure:', result);
-                process.exit(1);
-              }
-
-              return result.data.repository.pullRequests.nodes;
-            } catch (error) {
-              console.error('Error fetching PRs:', error);
-              throw error;
-            }
-          }
-
-          // Run the main function
-          getAllPRs().then(allPRs => {
-            const draftHIPPRs = allPRs.filter(pr => {
-              if (!pr.files || !pr.files.edges) {
-                return false;
-              }
-              const hipFiles = pr.files.edges.filter(edge => {
-                const fileNode = edge.node;
-                const isNewHIPFile = /^HIP\/hip-[a-zA-Z0-9-]+\.md$/.test(fileNode.path);
-                return fileNode.changeType === 'ADDED' && isNewHIPFile;
-              }).map(edge => edge.node);
-
-              return hipFiles.length > 0;
-            });
-
-            const outputPath = '_data/draft_hips.json';
-            
-            if (fs.existsSync(outputPath)) {
-              console.log(`Removing existing file: ${outputPath}`);
-              fs.unlinkSync(outputPath);
-            }
-            
-            console.log(`Writing ${draftHIPPRs.length} filtered PRs to: ${outputPath}`);
-            fs.writeFileSync(outputPath, JSON.stringify(draftHIPPRs, null, 2));
-          }).catch(error => {
-            console.error('Failed to fetch and filter PRs:', error);
-            process.exit(1);
-          });
-          EOF
-
-      - name: Run Script
-        run: node fetch-draft-hips.js
+      - name: Trigger Netlify build (re-fetches open draft-HIP PRs at build time)
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-
-      - name: Commit and Push Changes
-        env:
-          GITHUB_USER_EMAIL: ${{ vars.GIT_USER_EMAIL }}
-          GITHUB_USER_NAME: ${{ vars.GIT_USER_NAME }}
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
         run: |
-          set -e
-          git config --local user.email "$GITHUB_USER_EMAIL"
-          git config --local user.name "$GITHUB_USER_NAME"
-          git add _data/draft_hips.json
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          
-          git commit -s -S -m "Update draft HIPs data [skip ci]"
-          git push origin main
-          set +e
+          if [ -z "$NETLIFY_BUILD_HOOK" ]; then
+            echo "NETLIFY_BUILD_HOOK secret not set — skipping."
+            echo "Add the secret (Netlify build hook URL) to enable scheduled draft-HIP refreshes."
+            exit 0
+          fi
+          curl -fsS -X POST -d '{}' "$NETLIFY_BUILD_HOOK" && echo "Netlify build triggered."

--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -135,12 +135,72 @@ for (const file of files) {
 console.log(`Parsed ${hips.length} merged HIPs`);
 
 // ---- Fetch draft HIPs from open PRs ----
+// Draft HIPs exist only as open PRs (not yet merged). We fetch that list live at
+// build time via the GitHub GraphQL API, so nothing has to be committed to the
+// repo. Falls back to a committed _data/draft_hips.json when no GITHUB_TOKEN is
+// available (e.g. local dev), preserving the previous behavior.
 const draftHipsPath = path.join(DATA_DIR, 'draft_hips.json');
 
-async function fetchDraftHips() {
-  if (!fs.existsSync(draftHipsPath)) return;
+async function getDraftPRs() {
+  const token = process.env.GITHUB_TOKEN;
 
-  const draftPRs = JSON.parse(fs.readFileSync(draftHipsPath, 'utf-8'));
+  if (token) {
+    const query = `query {
+      repository(owner: "${REPO_OWNER}", name: "${REPO_NAME}") {
+        pullRequests(first: 100, states: [OPEN], orderBy: { field: CREATED_AT, direction: DESC }) {
+          nodes {
+            title
+            number
+            url
+            headRefOid
+            files(first: 100) { edges { node { path changeType additions deletions } } }
+            author { login }
+          }
+        }
+      }
+    }`;
+
+    try {
+      const res = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'hips-build',
+        },
+        body: JSON.stringify({ query }),
+      });
+      const json = await res.json();
+      if (json.errors) {
+        console.warn(`  Draft-HIP PR fetch: ${json.errors[0]?.message || 'GraphQL error'} — falling back to committed data`);
+      } else {
+        const nodes = json.data?.repository?.pullRequests?.nodes || [];
+        // Keep only PRs that ADD a new HIP/hip-*.md file — the same filter the
+        // old update-draft-hips.yml workflow used to produce _data/draft_hips.json.
+        const drafts = nodes.filter(pr =>
+          (pr.files?.edges || []).some(e =>
+            e.node.changeType === 'ADDED' &&
+            /^HIP\/hip-[A-Za-z0-9-]+\.md$/.test(e.node.path)
+          )
+        );
+        console.log(`Fetched ${drafts.length} open draft-HIP PRs from GitHub`);
+        return drafts;
+      }
+    } catch (e) {
+      console.warn(`  Draft-HIP PR fetch failed (${e.message}) — falling back to committed data`);
+    }
+  } else {
+    console.log('No GITHUB_TOKEN set — using committed _data/draft_hips.json if present');
+  }
+
+  if (fs.existsSync(draftHipsPath)) {
+    return JSON.parse(fs.readFileSync(draftHipsPath, 'utf-8'));
+  }
+  return [];
+}
+
+async function fetchDraftHips() {
+  const draftPRs = await getDraftPRs();
   let fetched = 0;
   let skipped = 0;
 


### PR DESCRIPTION
## Why

`update-draft-hips.yml` regenerates `_data/draft_hips.json` and **pushes it straight to `main` every 6 hours**. Those bot commits are **~19 of the last 30 changesets** — the dominant drag on the OpenSSF Scorecard **Code-Review** check (3/10), and they also hold back **SAST** (7/10) because direct pushes to `main` skip PR-based CodeQL.

## What

The site build **already** fetches live GitHub data at build time (discussion comments, PR review threads) via the GraphQL API. This moves the draft-HIP PR list onto the same mechanism:

- **`site/scripts/build-data.js`** — `fetchDraftHips()` now queries open PRs live via GraphQL (same query + "adds a new `HIP/hip-*.md`" filter the workflow used). Falls back to the committed `_data/draft_hips.json` when no `GITHUB_TOKEN` is present (local dev).
- **`update-draft-hips.yml`** — no longer generates or commits anything. It now just triggers a Netlify rebuild on the same 6h schedule, so the site stays current with **zero commits to `main`**.

`_data/draft_hips.json` is intentionally left in place as a local-dev fallback.

## Draft-HIP data is fully preserved (verified locally)

```
Parsed 157 merged HIPs
Fetched 15 open draft-HIP PRs from GitHub
Fetched 15 draft HIPs from open PRs (0 already merged)
→ public/data/hips.*.json: 172 HIPs total, 15 with prNumber (draft)
```

All 15 open draft HIPs (PR-1508, 1500, 1497 … 1068) are fetched and rendered exactly as before — just live instead of from a committed file. **The Netlify deploy preview on this PR is the end-to-end proof:** if drafts render there, production will too.

## ⚠️ Netlify prerequisites before merge
1. **`GITHUB_TOKEN` must be set in the Netlify build environment.** It almost certainly already is — the existing discussion-comment and PR-review-thread features use the same `process.env.GITHUB_TOKEN`. (The deploy preview showing drafts confirms it.)
2. **Add a `NETLIFY_BUILD_HOOK` repo secret** (a Netlify build hook URL) to keep the 6h scheduled refresh. Until it's set, the scheduled job is a harmless no-op and the site still rebuilds on every push to `main`.

## Impact
Removes the single largest source of unreviewed changesets → **Code-Review** climbs toward 8–9 as the 30-changeset window rolls forward, and **SAST** rises since remaining changes go through PRs. Trailing metric — improves over days, not instantly.
