### PR TITLE
test: add property-based fuzzing for HIP parsers (fixes 3 build-crash bugs)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,6 +13,9 @@
         "marked-highlight": "^2.2.3",
         "mermaid": "^11.13.0",
         "vite": "^6.4.2"
+      },
+      "devDependencies": {
+        "fast-check": "^3.23.2"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1782,6 +1785,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2142,6 +2168,23 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,8 @@
     "build:data": "node scripts/build-data.js",
     "dev": "npm run build:data && vite",
     "build": "npm run build:data && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test scripts/hip-parse.test.js"
   },
   "dependencies": {
     "gray-matter": "^4.0.3",
@@ -16,5 +17,8 @@
     "marked-highlight": "^2.2.3",
     "mermaid": "^11.13.0",
     "vite": "^6.4.2"
+  },
+  "devDependencies": {
+    "fast-check": "^3.23.2"
   }
 }

--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import matter from 'gray-matter';
+import {
+  parseMarkdown,
+  extractHip,
+  draftHipNumber,
+  replaceHipImages,
+} from './hip-parse.js';
 
 const HIP_DIR = path.resolve('../HIP');
 const DATA_DIR = path.resolve('../_data');
@@ -27,97 +32,10 @@ if (fs.existsSync(ASSETS_DIR)) {
   console.log('Copied assets/ to public/assets/');
 }
 
-function parseMarkdown(raw) {
-  try {
-    return matter(raw);
-  } catch (e) {
-    // Fallback: manual frontmatter parse for files with YAML issues
-    const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-    if (!match) return null;
-    const dataMap = new Map();
-    for (const line of match[1].split('\n')) {
-      const idx = line.indexOf(':');
-      if (idx === -1) continue;
-      dataMap.set(line.slice(0, idx).trim(), line.slice(idx + 1).trim());
-    }
-    return { data: Object.fromEntries(dataMap), content: match[2] };
-  }
-}
-
-function extractHip(data, content, extra = {}) {
-  return {
-    hip: data.hip,
-    title: data.title || '',
-    author: data.author || '',
-    type: data.type || '',
-    category: data.category || '',
-    status: data.status || '',
-    created: data.created || '',
-    updated: data.updated || '',
-    'discussions-to': data['discussions-to'] || '',
-    'needs-hiero-approval': data['needs-hiero-approval'] || '',
-    'needs-hedera-review': data['needs-hedera-review'] || data['needs-council-approval'] || '',
-    'last-call-date-time': data['last-call-date-time'] || '',
-    'requested-by': data['requested-by'] || '',
-    'working-group': data['working-group'] || '',
-    requires: data.requires || '',
-    'superseded-by': data['superseded-by'] || '',
-    replaces: data.replaces || '',
-    release: data.release || '',
-    ...extra,
-  };
-}
-
-function parsePositiveInteger(value) {
-  if (value === null || value === undefined) return null;
-
-  const normalized = String(value).trim().replace(/^['"]|['"]$/g, '');
-  if (!/^\d+$/.test(normalized)) return null;
-
-  const parsed = Number(normalized);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function draftHipNumber(frontmatterHip, prNumber, filePath) {
-  const frontmatterNumber = parsePositiveInteger(frontmatterHip);
-  if (frontmatterNumber) return frontmatterNumber;
-
-  const fileNumber = parsePositiveInteger(filePath.match(/^HIP\/hip-(\d+)(?:-[^/]*)?\.md$/i)?.[1]);
-  return fileNumber || prNumber;
-}
+// HIP frontmatter/markdown parsing helpers now live in ./hip-parse.js (imported
+// above) so they can be property-tested independently. See hip-parse.test.js.
 
 // ---- Parse merged HIPs from the HIP/ directory ----
-// ---- ASCII state diagrams to replace broken image references ----
-// For merged HIPs, assets are copied into public/assets/ so we rewrite ../assets/ → /assets/.
-// For draft HIPs, the assets live only on the PR branch, so we rewrite to raw.githubusercontent.com
-// pinned to the PR's commit SHA. GitHub serves commits from open PR forks via the upstream repo URL.
-function replaceHipImages(content, { rawBase, availableAssets } = {}) {
-  // Replace image references with placeholders (actual mermaid divs injected post-markdown in main.js)
-  content = content.replace(/!\[HIP States\]\([^)]*hip-states-standards-track\.[^)]*\)/g, '<!--DIAGRAM:STANDARDS_TRACK-->');
-  content = content.replace(/!\[HIP States\]\([^)]*hip-states-ipa\.[^)]*\)/g, '<!--DIAGRAM:IPA-->');
-
-  // For draft HIPs we know exactly which asset files exist in the PR. Replace
-  // markdown image references to assets that are NOT in the PR with a friendly
-  // placeholder so the page doesn't show a broken-image icon. (Common cause:
-  // author wrote ![alt](../assets/hipN/foo.png) but forgot to commit foo.png.)
-  if (availableAssets) {
-    content = content.replace(
-      /!\[([^\]]*)\]\(\s*\.\.\/(assets\/[^)\s]+)(?:\s+["'][^"']*["'])?\s*\)/g,
-      (match, alt, assetPath) => {
-        const decoded = decodeURIComponent(assetPath);
-        if (availableAssets.has(decoded)) return match;
-        const label = alt || decoded.split('/').pop();
-        return `<div class="missing-diagram"><strong>Diagram missing from PR:</strong> <code>${decoded}</code><br><span>(${label})</span></div>`;
-      }
-    );
-  }
-
-  // Rewrite remaining relative asset paths. Draft HIPs use the PR-pinned raw URL; merged HIPs use /assets/.
-  const replacement = rawBase ? `${rawBase}/assets/` : '/assets/';
-  content = content.replace(/\.\.\/assets\//g, replacement);
-  return content;
-}
-
 const files = fs.readdirSync(HIP_DIR).filter(f => f.endsWith('.md'));
 const hips = [];
 const hipBodies = new Map();

--- a/site/scripts/hip-parse.js
+++ b/site/scripts/hip-parse.js
@@ -1,0 +1,109 @@
+// Pure HIP parsing/formatting helpers, extracted from build-data.js so they can
+// be unit- and property-tested in isolation (see hip-parse.test.js) without
+// running the full build. Kept dependency-light (gray-matter only) and free of
+// filesystem/network side effects.
+import matter from 'gray-matter';
+
+export function parseMarkdown(raw) {
+  try {
+    return matter(raw);
+  } catch (e) {
+    // Fallback: manual frontmatter parse for files with YAML issues
+    const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (!match) return null;
+    const dataMap = new Map();
+    for (const line of match[1].split('\n')) {
+      const idx = line.indexOf(':');
+      if (idx === -1) continue;
+      dataMap.set(line.slice(0, idx).trim(), line.slice(idx + 1).trim());
+    }
+    return { data: Object.fromEntries(dataMap), content: match[2] };
+  }
+}
+
+export function extractHip(data, content, extra = {}) {
+  return {
+    hip: data.hip,
+    title: data.title || '',
+    author: data.author || '',
+    type: data.type || '',
+    category: data.category || '',
+    status: data.status || '',
+    created: data.created || '',
+    updated: data.updated || '',
+    'discussions-to': data['discussions-to'] || '',
+    'needs-hiero-approval': data['needs-hiero-approval'] || '',
+    'needs-hedera-review': data['needs-hedera-review'] || data['needs-council-approval'] || '',
+    'last-call-date-time': data['last-call-date-time'] || '',
+    'requested-by': data['requested-by'] || '',
+    'working-group': data['working-group'] || '',
+    requires: data.requires || '',
+    'superseded-by': data['superseded-by'] || '',
+    replaces: data.replaces || '',
+    release: data.release || '',
+    ...extra,
+  };
+}
+
+export function parsePositiveInteger(value) {
+  if (value === null || value === undefined) return null;
+
+  // String(value) can throw for exotic objects (e.g. a non-callable toString
+  // arriving from malformed YAML frontmatter); treat those as "not a number".
+  let normalized;
+  try {
+    normalized = String(value).trim().replace(/^['"]|['"]$/g, '');
+  } catch {
+    return null;
+  }
+  if (!/^\d+$/.test(normalized)) return null;
+
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function draftHipNumber(frontmatterHip, prNumber, filePath) {
+  const frontmatterNumber = parsePositiveInteger(frontmatterHip);
+  if (frontmatterNumber) return frontmatterNumber;
+
+  const fileNumber = parsePositiveInteger(filePath.match(/^HIP\/hip-(\d+)(?:-[^/]*)?\.md$/i)?.[1]);
+  return fileNumber || prNumber;
+}
+
+// For merged HIPs, assets are copied into public/assets/ so we rewrite ../assets/ → /assets/.
+// For draft HIPs, the assets live only on the PR branch, so we rewrite to raw.githubusercontent.com
+// pinned to the PR's commit SHA. GitHub serves commits from open PR forks via the upstream repo URL.
+export function replaceHipImages(content, { rawBase, availableAssets } = {}) {
+  // Replace image references with placeholders (actual mermaid divs injected post-markdown in main.js)
+  content = content.replace(/!\[HIP States\]\([^)]*hip-states-standards-track\.[^)]*\)/g, '<!--DIAGRAM:STANDARDS_TRACK-->');
+  content = content.replace(/!\[HIP States\]\([^)]*hip-states-ipa\.[^)]*\)/g, '<!--DIAGRAM:IPA-->');
+
+  // For draft HIPs we know exactly which asset files exist in the PR. Replace
+  // markdown image references to assets that are NOT in the PR with a friendly
+  // placeholder so the page doesn't show a broken-image icon. (Common cause:
+  // author wrote ![alt](../assets/hipN/foo.png) but forgot to commit foo.png.)
+  if (availableAssets) {
+    content = content.replace(
+      /!\[([^\]]*)\]\(\s*\.\.\/(assets\/[^)\s]+)(?:\s+["'][^"']*["'])?\s*\)/g,
+      (match, alt, assetPath) => {
+        // Untrusted PR content can contain malformed percent-encoding (e.g. a
+        // literal "%" in an asset path); decodeURIComponent throws URIError on
+        // those, which would abort the whole build. Fall back to the raw path.
+        let decoded;
+        try {
+          decoded = decodeURIComponent(assetPath);
+        } catch {
+          decoded = assetPath;
+        }
+        if (availableAssets.has(decoded)) return match;
+        const label = alt || decoded.split('/').pop();
+        return `<div class="missing-diagram"><strong>Diagram missing from PR:</strong> <code>${decoded}</code><br><span>(${label})</span></div>`;
+      }
+    );
+  }
+
+  // Rewrite remaining relative asset paths. Draft HIPs use the PR-pinned raw URL; merged HIPs use /assets/.
+  const replacement = rawBase ? `${rawBase}/assets/` : '/assets/';
+  content = content.replace(/\.\.\/assets\//g, replacement);
+  return content;
+}

--- a/site/scripts/hip-parse.test.js
+++ b/site/scripts/hip-parse.test.js
@@ -1,0 +1,79 @@
+// Property-based tests (fuzzing) for the HIP parsing helpers.
+//
+// Draft HIPs are pulled from open PRs, i.e. untrusted input, so these parsers
+// must never throw on arbitrary/malformed content — a crash here would break the
+// entire site build. fast-check generates many random inputs per property to try
+// to violate that invariant.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fc from 'fast-check';
+import {
+  parseMarkdown,
+  extractHip,
+  parsePositiveInteger,
+  draftHipNumber,
+  replaceHipImages,
+} from './hip-parse.js';
+
+const RUNS = { numRuns: 1000 };
+
+test('parseMarkdown never throws on arbitrary input', () => {
+  fc.assert(
+    fc.property(fc.string(), (raw) => {
+      parseMarkdown(raw);
+    }),
+    RUNS,
+  );
+});
+
+test('parseMarkdown -> extractHip handles frontmatter-shaped input', () => {
+  const frontmatterish = fc
+    .tuple(fc.string(), fc.string())
+    .map(([fm, body]) => `---\n${fm}\n---\n${body}`);
+  fc.assert(
+    fc.property(frontmatterish, (raw) => {
+      const parsed = parseMarkdown(raw);
+      if (parsed) extractHip(parsed.data || {}, parsed.content || '');
+    }),
+    RUNS,
+  );
+});
+
+test('parsePositiveInteger is total and returns null or a positive integer', () => {
+  fc.assert(
+    fc.property(fc.anything(), (v) => {
+      const out = parsePositiveInteger(v);
+      assert.ok(out === null || (Number.isInteger(out) && out > 0));
+    }),
+    RUNS,
+  );
+});
+
+test('draftHipNumber never throws for arbitrary frontmatter/path', () => {
+  fc.assert(
+    fc.property(fc.anything(), fc.integer(), fc.string(), (hip, pr, filePath) => {
+      draftHipNumber(hip, pr, filePath);
+    }),
+    RUNS,
+  );
+});
+
+test('replaceHipImages never throws on untrusted image paths', () => {
+  // Draft-HIP bodies come straight from PR branches and routinely contain
+  // ../assets/... image references with arbitrary (possibly malformed) paths.
+  const imageRef = fc.string().map((s) => `![diagram](../assets/${s})`);
+  const content = fc.oneof(
+    fc.string(),
+    imageRef,
+    fc.array(imageRef).map((a) => a.join('\n')),
+  );
+  fc.assert(
+    fc.property(content, (body) => {
+      replaceHipImages(body, {
+        rawBase: 'https://raw.githubusercontent.com/o/r/abc123',
+        availableAssets: new Set(),
+      });
+    }),
+    RUNS,
+  );
+});


### PR DESCRIPTION
## Why

Raises the OpenSSF Scorecard **Fuzzing** check (currently 0/10). Scorecard recognizes **property-based testing in JavaScript** (a `fast-check` import) as fuzzing — but rather than add a token test, this fuzzes the parsers that actually process **untrusted input**: HIP front-matter/markdown coming from open draft-HIP PRs.

## What

- **`site/scripts/hip-parse.js`** (new) — the pure parsing helpers (`parseMarkdown`, `extractHip`, `parsePositiveInteger`, `draftHipNumber`, `replaceHipImages`) extracted from `build-data.js` into a side-effect-free module so they can be tested in isolation. `build-data.js` now imports them — **no change to build behavior** (verified: still parses 157 merged + 15 draft HIPs).
- **`site/scripts/hip-parse.test.js`** (new) — `fast-check` property tests asserting the parsers never throw on arbitrary/malformed input. Run via `npm test`.
- **`fast-check`** added as a dev dependency.

## The fuzzer immediately found 3 real build-crash bugs

Each is reachable from a single malformed draft-HIP PR and would abort the **entire** site build:

| Input | Crash |
|---|---|
| `replaceHipImages("![x](../assets/%)")` | `URIError: URI malformed` (unguarded `decodeURIComponent`) |
| `parsePositiveInteger({ toString: [] })` | `TypeError` (unguarded `String()` on exotic YAML objects) |
| `draftHipNumber(…)` | same, via `parsePositiveInteger` |

All three now fall back gracefully instead of throwing. So beyond the Scorecard bump, this is a genuine robustness fix: a malformed image path or frontmatter value in one PR can no longer take down the whole build.

## Verification

```
npm test            -> 5 pass, 0 fail
npm run build:data  -> Parsed 157 merged HIPs / 15 draft HIPs (unchanged)
```

> Note: tests run via `npm test` in `site/`. Wiring them into a CI workflow is a trivial follow-up — kept out of this PR to avoid assumptions about runner setup.
