### PR TITLE
fix(site): override deep transitive deps to clear last 3 vuln alerts

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1857,9 +1857,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -1915,9 +1915,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/marked": {
@@ -2278,9 +2278,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/site/package.json
+++ b/site/package.json
@@ -20,5 +20,11 @@
   },
   "devDependencies": {
     "fast-check": "^3.23.2"
+  },
+  "//overrides": "Patched versions of deep transitive deps that have no Dependabot PR (no parent bump reaches them). Each has a single consumer and stays within its existing major; js-yaml is held on the 3.x line that gray-matter's API requires.",
+  "overrides": {
+    "lodash-es": "^4.18.0",
+    "js-yaml": "^3.15.0",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## What

Clears the **last 3 vulnerability alerts** (1 high, 2 moderate) — taking `site/` to **0 open vulnerabilities**. These are the deep-transitive deps that Dependabot **can't** open a PR for, because no parent version bump reaches them:

| Package | Severity | Advisory | Via | Override |
|---|---|---|---|---|
| `lodash-es` | **high** + moderate | `_.template` code injection + prototype pollution | dagre-d3-es | `^4.18.0` |
| `js-yaml` | moderate | ReDoS in merge-key handling | gray-matter | `^3.15.0` |
| `uuid` | moderate | buffer bounds check | mermaid | `^11.1.1` |

Fixed with a small `overrides` block in `site/package.json`. Each override has a single consumer and stays within its existing major; **`js-yaml` is held on the 3.x line** that gray-matter's API requires (js-yaml 4 renamed `safeLoad`→`load`).

## Follows the 3 merged Dependabot PRs
This is **not** a duplicate of Dependabot's work — #1501 (vite), #1498 (dompurify), #1481 (mermaid+uuid) already merged. This fixes only what those left behind. Note `uuid` needed an override because the mermaid bump in #1481 left `uuid` pinned below the patched version.

## Verified on Linux (Netlify's build OS, node:20)
```
npm ci        → clean
npm audit     → found 0 vulnerabilities   (was 3)
npm test      → 5 pass, 0 fail
npm run build → exit 0 · Parsed 157 merged + 15 draft = 172 HIPs · ✓ built
```
Only `site/package.json` + `site/package-lock.json` change. No source or build-behavior changes.

## Heads-up on the Netlify check
The `hedera-hips` Netlify preview check will likely show red — that's the **pre-existing preview-deploy issue** that fails on *every* `site/` PR (it failed identically on all 3 Dependabot PRs). The build itself is verified green on Linux above; it is not caused by this change.
