### PR TITLE
Make HIP content AI-readable

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -41,17 +41,13 @@ jobs:
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - name: Build data
-        working-directory: site
-        run: npm run build:data
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build site
         working-directory: site
         run: npm run build
         env:
           VITE_BASE: ${{ steps.pages.outputs.base_path }}/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SITE_URL: https://hips.hedera.com
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](./assets/hiero_logo.png)
 
 [![](https://img.shields.io/discord/905194001349627914)](https://discord.com/channels/905194001349627914/1289954446712770600)
-[![](https://img.shields.io/badge/view-published-blue)](https://hips.hedera.org)
+[![](https://img.shields.io/badge/view-published-blue)](https://hips.hedera.com)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hiero-ledger/hiero-improvement-proposals/badge)](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-improvement-proposals)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/10697/badge)](https://bestpractices.coreinfrastructure.org/projects/10697)
 [![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
@@ -28,7 +28,28 @@ author is responsible for building consensus within the community and
 documenting dissenting opinions, as well as tracking their HIP through
 the process outlined below.
 
-You can see the list of all HIPs on [the official HIPs site](https://hips.hiero.org).
+You can see the list of all HIPs on [the official HIPs site](https://hips.hedera.com).
+
+## AI-readable site data
+
+The site build publishes static, non-JavaScript resources so search crawlers,
+language models, and other tools can read the complete HIP corpus without
+rendering the interactive application:
+
+- `/llms.txt` is the compact discovery index.
+- `/llms-full.txt` contains every merged HIP and open-pull-request draft in one
+  Markdown document.
+- `/api/hips/index.json` is a metadata-only catalog, while `/api/hips.json` and
+  `/api/hips/{number}.json` include full Markdown content.
+- `/hip/hip-{number}.md` provides one directly fetchable Markdown document.
+- `/sitemap.xml` and `/robots.txt` expose all human and machine-readable URLs to
+  crawlers.
+
+Draft entries carry `isDraft: true`, their pull request URL and commit SHA, and
+an explicit warning that they are not adopted specifications. During deploys,
+`GITHUB_TOKEN` is used to paginate through all open pull requests and fetch the
+draft content pinned to each PR's current commit. `SITE_URL` can override the
+default canonical host (`https://hips.hedera.com`).
 
 ## What is Hiero?
 [Hiero](https://hiero.org) is an open-source distributed ledger project under

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@
   publish = "dist"
 
 [[redirects]]
+  from = "/hip/hip-:number"
+  to = "/hip/hip-:number.html"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,4 +1,11 @@
 node_modules/
 public/data/
 public/assets/
+public/api/
+public/hip/
+public/llm.txt
+public/llms.txt
+public/llms-full.txt
+public/robots.txt
+public/sitemap.xml
 dist/

--- a/site/index.html
+++ b/site/index.html
@@ -5,15 +5,43 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hiero Improvement Proposals</title>
   <meta name="description" content="Browse, search, and filter all Hiero Improvement Proposals.">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
   <meta property="og:title" content="Hiero Improvement Proposals">
   <meta property="og:description" content="Browse, search, and filter all Hiero Improvement Proposals.">
+  <link rel="alternate" type="text/plain" href="/llms.txt" title="HIP index for language models">
+  <link rel="alternate" type="application/json" href="/api/hips.json" title="Complete HIP catalog">
+  <link rel="sitemap" type="application/xml" href="/sitemap.xml">
   <link rel="icon" href="/favicon.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/src/style.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "name": "Hiero Improvement Proposals",
+      "description": "Canonical collection of merged Hiero Improvement Proposals and drafts from open pull requests.",
+      "url": "https://hips.hedera.com/",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "Hiero Improvement Proposals",
+        "url": "https://hips.hedera.com/"
+      },
+      "mainEntity": {
+        "@type": "Dataset",
+        "name": "Hiero Improvement Proposals corpus",
+        "url": "https://hips.hedera.com/api/hips.json",
+        "encodingFormat": "application/json",
+        "license": "https://www.apache.org/licenses/LICENSE-2.0"
+      }
+    }
+  </script>
 </head>
 <body>
+  <noscript>
+    <p>JavaScript is only required for the interactive browser. Read the complete HIP corpus in <a href="/llms-full.txt">Markdown</a> or <a href="/api/hips.json">JSON</a>.</p>
+  </noscript>
   <header class="site-header">
     <div class="header-inner">
       <div class="header-left">
@@ -229,6 +257,8 @@
       <a href="https://github.com/hiero-ledger/hiero-improvement-proposals" target="_blank">GitHub</a>
       <span class="sep">&middot;</span>
       <a href="https://discord.com/channels/905194001349627914/1289954446712770600" target="_blank">Discord</a>
+      <span class="sep">&middot;</span>
+      <a href="/llms.txt">AI / Data</a>
     </div>
   </footer>
 

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
     "dev": "npm run build:data && vite",
     "build": "npm run build:data && vite build",
     "preview": "vite preview",
-    "test": "node --test scripts/hip-parse.test.js"
+    "test": "node --test scripts/*.test.js"
   },
   "dependencies": {
     "gray-matter": "^4.0.3",

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,37 @@
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  Access-Control-Allow-Origin: *
+  X-Robots-Tag: index, follow
+  Cache-Control: public, max-age=3600, s-maxage=21600
+
+/llm.txt
+  Content-Type: text/plain; charset=utf-8
+  Access-Control-Allow-Origin: *
+  X-Robots-Tag: index, follow
+  Cache-Control: public, max-age=3600, s-maxage=21600
+
+/llms-full.txt
+  Content-Type: text/plain; charset=utf-8
+  Access-Control-Allow-Origin: *
+  X-Robots-Tag: index, follow
+  Cache-Control: public, max-age=3600, s-maxage=21600
+
+/hip/*.md
+  Content-Type: text/markdown; charset=utf-8
+  Access-Control-Allow-Origin: *
+  X-Robots-Tag: index, follow
+  Cache-Control: public, max-age=3600, s-maxage=21600
+
+/api/*
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  X-Robots-Tag: index, follow
+  Cache-Control: public, max-age=3600, s-maxage=21600
+
+/sitemap.xml
+  Content-Type: application/xml; charset=utf-8
+  Cache-Control: public, max-age=3600, s-maxage=21600
+
+/robots.txt
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=3600, s-maxage=21600

--- a/site/scripts/ai-artifacts.js
+++ b/site/scripts/ai-artifacts.js
@@ -1,0 +1,282 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+export const DEFAULT_SITE_URL = 'https://hips.hedera.com';
+
+function normalizeSiteUrl(value) {
+  const url = new URL(value || DEFAULT_SITE_URL);
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/$/, '');
+}
+
+function jsonSafe(value) {
+  return JSON.parse(JSON.stringify(value ?? null));
+}
+
+function cleanText(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function markdownLabel(value) {
+  return cleanText(value).replace(/[\\[\]]/g, '\\$&');
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function isoDate(value) {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+function absoluteContentUrls(content, siteUrl) {
+  return String(content || '')
+    .replace(/\]\(\/(?!\/)/g, `](${siteUrl}/`)
+    .replace(/\b(src|href)=(['"])\/(?!\/)/g, `$1=$2${siteUrl}/`);
+}
+
+function emptyGeneratedFiles(directory, extension) {
+  fs.mkdirSync(directory, { recursive: true });
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(extension)) {
+      fs.unlinkSync(path.join(directory, entry.name));
+    }
+  }
+}
+
+function writeUtf8(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content.endsWith('\n') ? content : `${content}\n`, 'utf8');
+}
+
+function prepareDocuments(documents, siteUrl) {
+  const seen = new Set();
+
+  return documents
+    .map((document) => {
+      const metadata = jsonSafe(document.metadata || document.hip || {});
+      const number = Number(metadata.hip ?? document.hip?.hip);
+      if (!Number.isSafeInteger(number) || number <= 0) {
+        throw new Error(`Cannot generate AI artifact for invalid HIP number: ${metadata.hip}`);
+      }
+      if (seen.has(number)) throw new Error(`Cannot generate duplicate HIP-${number} artifact`);
+      seen.add(number);
+
+      const source = jsonSafe(document.source || {});
+      const urls = {
+        html: `${siteUrl}/hip/hip-${number}`,
+        markdown: `${siteUrl}/hip/hip-${number}.md`,
+        json: `${siteUrl}/api/hips/${number}.json`,
+        repository: source.url || '',
+        discussion: metadata['discussions-to'] || '',
+      };
+      const content = absoluteContentUrls(document.body, siteUrl).trim();
+      const title = cleanText(metadata.title || document.hip?.title);
+      const isDraft = source.kind === 'pull_request';
+
+      const markdown = matter.stringify(`${content}\n`, {
+        ...metadata,
+        canonical: urls.html,
+        'machine-readable': urls.markdown,
+        'source-kind': isDraft ? 'open-pull-request' : 'merged',
+        'source-url': source.url || '',
+        'source-revision': source.commit || source.ref || '',
+        'source-path': source.path || '',
+      });
+
+      return {
+        hip: number,
+        title,
+        status: cleanText(metadata.status),
+        type: cleanText(metadata.type),
+        category: cleanText(metadata.category),
+        author: cleanText(metadata.author),
+        created: isoDate(metadata.created),
+        updated: isoDate(metadata.updated),
+        isDraft,
+        metadata,
+        source,
+        urls,
+        content,
+        markdown,
+      };
+    })
+    .sort((a, b) => a.hip - b.hip);
+}
+
+function indexRecord(document) {
+  const { content, markdown, ...record } = document;
+  return record;
+}
+
+function fullRecord(document) {
+  const { markdown, ...record } = document;
+  return record;
+}
+
+function llmsIndex(documents, siteUrl, generatedAt, sourceRevision) {
+  const merged = documents.filter((document) => !document.isDraft);
+  const drafts = documents.filter((document) => document.isDraft);
+  const lines = [
+    '# Hiero Improvement Proposals (HIPs)',
+    '',
+    '> Canonical index of Hiero Improvement Proposals, including merged HIPs and unmerged HIP drafts from open pull requests.',
+    '',
+    'Use the stable, non-JavaScript resources below. Open-pull-request drafts are proposals under review and must not be treated as adopted or final specifications.',
+    '',
+    '## Machine-readable resources',
+    '',
+    `- [Metadata index (JSON)](${siteUrl}/api/hips/index.json): Compact metadata, provenance, and content URLs for every HIP.`,
+    `- [Complete catalog (JSON)](${siteUrl}/api/hips.json): Metadata and full Markdown content for every HIP in one response.`,
+    `- [Complete catalog (Markdown)](${siteUrl}/llms-full.txt): Every HIP, including frontmatter and full proposal text, in one document.`,
+    `- [XML sitemap](${siteUrl}/sitemap.xml): Human and Markdown URLs for crawler discovery.`,
+    `- [Source repository](https://github.com/hiero-ledger/hiero-improvement-proposals): Canonical source and open pull requests.`,
+    '',
+    `Generated: ${generatedAt}`,
+  ];
+
+  if (sourceRevision) lines.push(`Source revision: ${sourceRevision}`);
+
+  const appendDocuments = (heading, description, items) => {
+    lines.push('', `## ${heading}`, '', description, '');
+    for (const document of items) {
+      const qualifiers = [document.status, document.type, document.category].filter(Boolean).join(' · ');
+      const suffix = qualifiers ? `: ${qualifiers}` : '';
+      lines.push(`- [HIP-${document.hip}: ${markdownLabel(document.title)}](${document.urls.markdown})${suffix}`);
+    }
+  };
+
+  appendDocuments(
+    'Merged HIPs',
+    'These documents are present on the repository default branch. Their lifecycle status is recorded in each document.',
+    merged,
+  );
+
+  appendDocuments(
+    'Open pull request drafts',
+    'These documents exist only in open pull requests. Follow each document’s source URL for the current review state.',
+    drafts,
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function llmsFull(documents, generatedAt, sourceRevision) {
+  const lines = [
+    '# Hiero Improvement Proposals: complete machine-readable corpus',
+    '',
+    `Generated: ${generatedAt}`,
+  ];
+  if (sourceRevision) lines.push(`Source revision: ${sourceRevision}`);
+  lines.push(
+    '',
+    '> Documents marked `source-kind: open-pull-request` are unmerged drafts under review, not adopted specifications.',
+    '',
+  );
+
+  for (const document of documents) {
+    lines.push(
+      `<!-- BEGIN HIP-${document.hip} -->`,
+      document.markdown.trim(),
+      `<!-- END HIP-${document.hip} -->`,
+      '',
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function sitemap(documents, siteUrl) {
+  const urls = [
+    { loc: `${siteUrl}/` },
+    { loc: `${siteUrl}/llms.txt` },
+    { loc: `${siteUrl}/llms-full.txt` },
+    { loc: `${siteUrl}/api/hips/index.json` },
+    { loc: `${siteUrl}/api/hips.json` },
+  ];
+
+  for (const document of documents) {
+    const lastmod = document.updated || document.created;
+    urls.push({ loc: document.urls.html, lastmod });
+    urls.push({ loc: document.urls.markdown, lastmod });
+  }
+
+  const body = urls.map(({ loc, lastmod }) => [
+    '  <url>',
+    `    <loc>${xmlEscape(loc)}</loc>`,
+    lastmod ? `    <lastmod>${lastmod}</lastmod>` : '',
+    '  </url>',
+  ].filter(Boolean).join('\n')).join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    body,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+export function writeAiArtifacts({
+  documents,
+  publicDir,
+  siteUrl = DEFAULT_SITE_URL,
+  generatedAt = new Date().toISOString(),
+  sourceRevision = '',
+}) {
+  const canonicalSiteUrl = normalizeSiteUrl(siteUrl);
+  const prepared = prepareDocuments(documents, canonicalSiteUrl);
+  const mergedCount = prepared.filter((document) => !document.isDraft).length;
+  const draftCount = prepared.length - mergedCount;
+  const index = prepared.map(indexRecord);
+  const full = prepared.map(fullRecord);
+  const envelope = {
+    schemaVersion: 1,
+    generatedAt,
+    sourceRevision: sourceRevision || null,
+    canonicalSite: canonicalSiteUrl,
+    repository: 'https://github.com/hiero-ledger/hiero-improvement-proposals',
+    notice: 'Entries with isDraft=true come from open pull requests and are not adopted specifications.',
+    counts: { total: prepared.length, merged: mergedCount, openPullRequestDrafts: draftCount },
+  };
+
+  const hipMarkdownDir = path.join(publicDir, 'hip');
+  const hipJsonDir = path.join(publicDir, 'api', 'hips');
+  emptyGeneratedFiles(hipMarkdownDir, '.md');
+  emptyGeneratedFiles(hipJsonDir, '.json');
+
+  for (const document of prepared) {
+    writeUtf8(path.join(hipMarkdownDir, `hip-${document.hip}.md`), document.markdown);
+    writeUtf8(
+      path.join(hipJsonDir, `${document.hip}.json`),
+      JSON.stringify({ ...envelope, hip: fullRecord(document) }, null, 2),
+    );
+  }
+
+  const llms = llmsIndex(prepared, canonicalSiteUrl, generatedAt, sourceRevision);
+  writeUtf8(path.join(publicDir, 'llms.txt'), llms);
+  writeUtf8(path.join(publicDir, 'llm.txt'), llms);
+  writeUtf8(path.join(publicDir, 'llms-full.txt'), llmsFull(prepared, generatedAt, sourceRevision));
+  writeUtf8(path.join(publicDir, 'api', 'hips', 'index.json'), JSON.stringify({ ...envelope, hips: index }, null, 2));
+  writeUtf8(path.join(publicDir, 'api', 'hips.json'), JSON.stringify({ ...envelope, hips: full }, null, 2));
+  writeUtf8(path.join(publicDir, 'sitemap.xml'), sitemap(prepared, canonicalSiteUrl));
+  writeUtf8(path.join(publicDir, 'robots.txt'), [
+    'User-agent: *',
+    'Allow: /',
+    '',
+    `Sitemap: ${canonicalSiteUrl}/sitemap.xml`,
+    '',
+  ].join('\n'));
+
+  return { total: prepared.length, merged: mergedCount, drafts: draftCount };
+}

--- a/site/scripts/ai-artifacts.test.js
+++ b/site/scripts/ai-artifacts.test.js
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { writeAiArtifacts } from './ai-artifacts.js';
+
+function document({ hip, title, body, source, status = 'Final' }) {
+  const metadata = {
+    hip,
+    title,
+    author: 'A. Author (@author)',
+    type: 'Standards Track',
+    category: 'Core',
+    status,
+    created: new Date('2026-01-02T00:00:00.000Z'),
+  };
+  return { hip: metadata, metadata, body, source };
+}
+
+test('writeAiArtifacts emits discoverable full-content resources and draft provenance', () => {
+  const publicDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hips-ai-artifacts-'));
+  fs.mkdirSync(path.join(publicDir, 'hip'), { recursive: true });
+  fs.writeFileSync(path.join(publicDir, 'hip', 'hip-999.md'), 'stale');
+
+  const result = writeAiArtifacts({
+    publicDir,
+    siteUrl: 'https://hips.hedera.com/',
+    generatedAt: '2026-07-20T12:00:00.000Z',
+    sourceRevision: 'abc123',
+    documents: [
+      document({
+        hip: 1,
+        title: 'HIP process',
+        body: '## Abstract\n\nMerged body.\n\n![diagram](/assets/hip-1/flow.png)',
+        source: {
+          kind: 'merged',
+          path: 'HIP/hip-1.md',
+          ref: 'abc123',
+          url: 'https://github.com/hiero-ledger/hiero-improvement-proposals/blob/abc123/HIP/hip-1.md',
+        },
+      }),
+      document({
+        hip: 1500,
+        title: 'Periodic Holding Fee',
+        body: '## Abstract\n\nDraft body only present in a PR.',
+        status: 'Draft',
+        source: {
+          kind: 'pull_request',
+          pullRequest: 1500,
+          commit: 'def456',
+          path: 'HIP/hip-0000-periodic-holding-fee.md',
+          author: 'AdrianKBL',
+          url: 'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1500',
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(result, { total: 2, merged: 1, drafts: 1 });
+  assert.equal(fs.existsSync(path.join(publicDir, 'hip', 'hip-999.md')), false);
+
+  const llms = fs.readFileSync(path.join(publicDir, 'llms.txt'), 'utf8');
+  assert.match(llms, /## Merged HIPs/);
+  assert.match(llms, /## Open pull request drafts/);
+  assert.match(llms, /HIP-1500: Periodic Holding Fee/);
+  assert.equal(fs.readFileSync(path.join(publicDir, 'llm.txt'), 'utf8'), llms);
+
+  const mergedMarkdown = fs.readFileSync(path.join(publicDir, 'hip', 'hip-1.md'), 'utf8');
+  assert.match(mergedMarkdown, /source-kind: merged/);
+  assert.match(mergedMarkdown, /https:\/\/hips\.hedera\.com\/assets\/hip-1\/flow\.png/);
+  assert.match(mergedMarkdown, /Merged body\./);
+
+  const draftMarkdown = fs.readFileSync(path.join(publicDir, 'hip', 'hip-1500.md'), 'utf8');
+  assert.match(draftMarkdown, /source-kind: open-pull-request/);
+  assert.match(draftMarkdown, /source-revision: def456/);
+  assert.match(draftMarkdown, /source-path: HIP\/hip-0000-periodic-holding-fee\.md/);
+  assert.match(draftMarkdown, /Draft body only present in a PR\./);
+
+  const index = JSON.parse(fs.readFileSync(path.join(publicDir, 'api', 'hips', 'index.json'), 'utf8'));
+  assert.deepEqual(index.counts, { total: 2, merged: 1, openPullRequestDrafts: 1 });
+  assert.equal(index.hips[1].isDraft, true);
+  assert.equal(index.hips[1].source.pullRequest, 1500);
+  assert.equal('content' in index.hips[0], false);
+
+  const full = JSON.parse(fs.readFileSync(path.join(publicDir, 'api', 'hips.json'), 'utf8'));
+  assert.equal(full.hips[1].content, '## Abstract\n\nDraft body only present in a PR.');
+
+  const oneHip = JSON.parse(fs.readFileSync(path.join(publicDir, 'api', 'hips', '1500.json'), 'utf8'));
+  assert.equal(oneHip.hip.urls.markdown, 'https://hips.hedera.com/hip/hip-1500.md');
+
+  const completeMarkdown = fs.readFileSync(path.join(publicDir, 'llms-full.txt'), 'utf8');
+  assert.match(completeMarkdown, /<!-- BEGIN HIP-1 -->/);
+  assert.match(completeMarkdown, /<!-- BEGIN HIP-1500 -->/);
+  assert.match(completeMarkdown, /Draft body only present in a PR\./);
+
+  const sitemap = fs.readFileSync(path.join(publicDir, 'sitemap.xml'), 'utf8');
+  assert.match(sitemap, /https:\/\/hips\.hedera\.com\/hip\/hip-1500\.md/);
+  assert.match(sitemap, /<lastmod>2026-01-02<\/lastmod>/);
+
+  const robots = fs.readFileSync(path.join(publicDir, 'robots.txt'), 'utf8');
+  assert.match(robots, /User-agent: \*/);
+  assert.match(robots, /Sitemap: https:\/\/hips\.hedera\.com\/sitemap\.xml/);
+});
+
+test('writeAiArtifacts rejects duplicate HIP numbers', () => {
+  const publicDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hips-ai-duplicates-'));
+  const first = document({ hip: 1, title: 'One', body: '', source: { kind: 'merged' } });
+  const second = document({ hip: 1, title: 'Duplicate', body: '', source: { kind: 'pull_request' } });
+
+  assert.throws(
+    () => writeAiArtifacts({ publicDir, documents: [first, second] }),
+    /duplicate HIP-1/,
+  );
+});

--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -6,10 +6,13 @@ import {
   draftHipNumber,
   replaceHipImages,
 } from './hip-parse.js';
+import { fetchOpenDraftPullRequests } from './github-drafts.js';
+import { DEFAULT_SITE_URL, writeAiArtifacts } from './ai-artifacts.js';
 
 const HIP_DIR = path.resolve('../HIP');
 const DATA_DIR = path.resolve('../_data');
 const ASSETS_DIR = path.resolve('../assets');
+const PUBLIC_DIR = path.resolve('public');
 const OUT_DIR = path.resolve('public/data');
 const PUBLIC_ASSETS = path.resolve('public/assets');
 const REPO_OWNER = 'hiero-ledger';
@@ -39,15 +42,32 @@ if (fs.existsSync(ASSETS_DIR)) {
 const files = fs.readdirSync(HIP_DIR).filter(f => f.endsWith('.md'));
 const hips = [];
 const hipBodies = new Map();
+const hipDocuments = new Map();
 const mergedHipNumbers = new Set();
 
 for (const file of files) {
   const raw = fs.readFileSync(path.join(HIP_DIR, file), 'utf-8');
   const parsed = parseMarkdown(raw);
   if (!parsed || !parsed.data.hip) continue;
-  mergedHipNumbers.add(Number(parsed.data.hip));
-  hips.push(extractHip(parsed.data, parsed.content));
-  hipBodies.set(String(parsed.data.hip), replaceHipImages(parsed.content));
+  const hipNumber = Number(parsed.data.hip);
+  const body = replaceHipImages(parsed.content);
+  const hip = extractHip(parsed.data, parsed.content);
+  const sourceRef = process.env.GITHUB_SHA || 'main';
+  const sourcePath = `HIP/${file}`;
+  mergedHipNumbers.add(hipNumber);
+  hips.push(hip);
+  hipBodies.set(String(hipNumber), body);
+  hipDocuments.set(String(hipNumber), {
+    hip,
+    metadata: parsed.data,
+    body,
+    source: {
+      kind: 'merged',
+      path: sourcePath,
+      ref: sourceRef,
+      url: `https://github.com/${REPO_OWNER}/${REPO_NAME}/blob/${sourceRef}/${sourcePath}`,
+    },
+  });
 }
 
 console.log(`Parsed ${hips.length} merged HIPs`);
@@ -63,47 +83,14 @@ async function getDraftPRs() {
   const token = process.env.GITHUB_TOKEN;
 
   if (token) {
-    const query = `query {
-      repository(owner: "${REPO_OWNER}", name: "${REPO_NAME}") {
-        pullRequests(first: 100, states: [OPEN], orderBy: { field: CREATED_AT, direction: DESC }) {
-          nodes {
-            title
-            number
-            url
-            headRefOid
-            files(first: 100) { edges { node { path changeType additions deletions } } }
-            author { login }
-          }
-        }
-      }
-    }`;
-
     try {
-      const res = await fetch('https://api.github.com/graphql', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-          'User-Agent': 'hips-build',
-        },
-        body: JSON.stringify({ query }),
+      const drafts = await fetchOpenDraftPullRequests({
+        token,
+        owner: REPO_OWNER,
+        repository: REPO_NAME,
       });
-      const json = await res.json();
-      if (json.errors) {
-        console.warn(`  Draft-HIP PR fetch: ${json.errors[0]?.message || 'GraphQL error'} — falling back to committed data`);
-      } else {
-        const nodes = json.data?.repository?.pullRequests?.nodes || [];
-        // Keep only PRs that ADD a new HIP/hip-*.md file — the same filter the
-        // old update-draft-hips.yml workflow used to produce _data/draft_hips.json.
-        const drafts = nodes.filter(pr =>
-          (pr.files?.edges || []).some(e =>
-            e.node.changeType === 'ADDED' &&
-            /^HIP\/hip-[A-Za-z0-9-]+\.md$/.test(e.node.path)
-          )
-        );
-        console.log(`Fetched ${drafts.length} open draft-HIP PRs from GitHub`);
-        return drafts;
-      }
+      console.log(`Fetched ${drafts.length} open draft-HIP PRs from GitHub`);
+      return drafts;
     } catch (e) {
       console.warn(`  Draft-HIP PR fetch failed (${e.message}) — falling back to committed data`);
     }
@@ -123,15 +110,10 @@ async function fetchDraftHips() {
   let skipped = 0;
 
   for (const pr of draftPRs) {
-    if (mergedHipNumbers.has(pr.number)) {
-      skipped++;
-      continue;
-    }
-
     // Find the HIP markdown file in this PR's changed files
     const hipFile = pr.files?.edges?.find(f =>
-      f.node.path.startsWith('HIP/') &&
-      f.node.path.endsWith('.md') &&
+      f.node.changeType === 'ADDED' &&
+      /^HIP\/hip-[A-Za-z0-9-]+\.md$/.test(f.node.path) &&
       !f.node.path.includes('template')
     );
 
@@ -160,6 +142,11 @@ async function fetchDraftHips() {
       // Draft PRs often retain placeholder frontmatter such as "hip: xxxx" or
       // "hip: <to be assigned>". Ignore those and use the assigned draft number.
       const hipNum = draftHipNumber(parsed.data.hip, pr.number, filePath);
+      if (mergedHipNumbers.has(hipNum) || hipDocuments.has(String(hipNum))) {
+        console.warn(`  PR-${pr.number}: HIP-${hipNum} already exists, skipping duplicate`);
+        skipped++;
+        continue;
+      }
 
       // Force status to Draft if not already set or if it differs
       const data = {
@@ -169,14 +156,29 @@ async function fetchDraftHips() {
         'discussions-to': parsed.data['discussions-to'] || pr.url || '',
       };
 
-      hips.push(extractHip(data, parsed.content, { prNumber: pr.number }));
+      const hip = extractHip(data, parsed.content, { prNumber: pr.number });
       const rawBase = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${pr.headRefOid}`;
       const availableAssets = new Set(
         (pr.files?.edges || [])
           .map(e => e.node.path)
           .filter(p => p.startsWith('assets/'))
       );
-      hipBodies.set(String(hipNum), replaceHipImages(parsed.content, { rawBase, availableAssets }));
+      const body = replaceHipImages(parsed.content, { rawBase, availableAssets });
+      hips.push(hip);
+      hipBodies.set(String(hipNum), body);
+      hipDocuments.set(String(hipNum), {
+        hip,
+        metadata: data,
+        body,
+        source: {
+          kind: 'pull_request',
+          pullRequest: pr.number,
+          commit: pr.headRefOid,
+          path: filePath,
+          author: pr.author?.login || '',
+          url: pr.url,
+        },
+      });
       fetched++;
       console.log(`  PR-${pr.number}: fetched HIP-${hipNum} "${data.title}"`);
     } catch (e) {
@@ -384,6 +386,17 @@ async function main() {
   await fetchDraftHips();
 
   hips.sort((a, b) => Number(a.hip) - Number(b.hip));
+
+  const aiArtifacts = writeAiArtifacts({
+    documents: [...hipDocuments.values()],
+    publicDir: PUBLIC_DIR,
+    siteUrl: process.env.SITE_URL || DEFAULT_SITE_URL,
+    sourceRevision: process.env.GITHUB_SHA || '',
+  });
+  console.log(
+    `Built AI-readable artifacts for ${aiArtifacts.total} HIPs ` +
+    `(${aiArtifacts.merged} merged, ${aiArtifacts.drafts} open-PR drafts)`,
+  );
 
   const [discussions, prReviews] = await Promise.all([
     fetchDiscussions(),

--- a/site/scripts/github-drafts.js
+++ b/site/scripts/github-drafts.js
@@ -1,0 +1,104 @@
+const DEFAULT_OWNER = 'hiero-ledger';
+const DEFAULT_REPOSITORY = 'hiero-improvement-proposals';
+
+const OPEN_PULL_REQUESTS_QUERY = `
+  query OpenPullRequests($owner: String!, $repository: String!, $cursor: String) {
+    repository(owner: $owner, name: $repository) {
+      pullRequests(
+        first: 100
+        after: $cursor
+        states: [OPEN]
+        orderBy: { field: CREATED_AT, direction: DESC }
+      ) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          title
+          number
+          url
+          headRefOid
+          files(first: 100) {
+            edges {
+              node {
+                path
+                changeType
+                additions
+                deletions
+              }
+            }
+          }
+          author {
+            login
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function isDraftHipPullRequest(pr) {
+  return (pr?.files?.edges || []).some(({ node }) =>
+    node?.changeType === 'ADDED' &&
+    /^HIP\/hip-[A-Za-z0-9-]+\.md$/.test(node.path)
+  );
+}
+
+/**
+ * Fetch every open pull request and retain those that add a HIP Markdown file.
+ * GitHub caps a GraphQL connection at 100 nodes, so following pageInfo is
+ * essential: older draft HIPs must not silently disappear from the site.
+ */
+export async function fetchOpenDraftPullRequests({
+  token,
+  fetchImpl = fetch,
+  owner = DEFAULT_OWNER,
+  repository = DEFAULT_REPOSITORY,
+} = {}) {
+  if (!token) throw new Error('A GitHub token is required to query open draft HIPs');
+
+  const drafts = [];
+  const seenCursors = new Set();
+  let cursor = null;
+
+  do {
+    const response = await fetchImpl('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'hips-build',
+      },
+      body: JSON.stringify({
+        query: OPEN_PULL_REQUESTS_QUERY,
+        variables: { owner, repository, cursor },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub GraphQL request failed with HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (payload.errors?.length) {
+      throw new Error(payload.errors[0]?.message || 'GitHub GraphQL request failed');
+    }
+
+    const connection = payload.data?.repository?.pullRequests;
+    if (!connection) throw new Error('GitHub GraphQL response did not include pull requests');
+
+    drafts.push(...(connection.nodes || []).filter(isDraftHipPullRequest));
+
+    if (!connection.pageInfo?.hasNextPage) break;
+
+    const nextCursor = connection.pageInfo.endCursor;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error('GitHub GraphQL pagination returned an invalid cursor');
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  } while (true);
+
+  return drafts;
+}

--- a/site/scripts/github-drafts.test.js
+++ b/site/scripts/github-drafts.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fetchOpenDraftPullRequests,
+  isDraftHipPullRequest,
+} from './github-drafts.js';
+
+function pr(number, path, changeType = 'ADDED') {
+  return {
+    number,
+    files: { edges: [{ node: { path, changeType } }] },
+  };
+}
+
+test('isDraftHipPullRequest only accepts newly added HIP Markdown files', () => {
+  assert.equal(isDraftHipPullRequest(pr(1500, 'HIP/hip-0000-periodic-fee.md')), true);
+  assert.equal(isDraftHipPullRequest(pr(1501, 'HIP/hip-1501.md', 'MODIFIED')), false);
+  assert.equal(isDraftHipPullRequest(pr(1502, 'README.md')), false);
+  assert.equal(isDraftHipPullRequest(null), false);
+});
+
+test('fetchOpenDraftPullRequests follows every GraphQL page', async () => {
+  const requests = [];
+  const pages = [
+    {
+      data: {
+        repository: {
+          pullRequests: {
+            nodes: [pr(1500, 'HIP/hip-0000-periodic-fee.md'), pr(1499, 'README.md')],
+            pageInfo: { hasNextPage: true, endCursor: 'page-2' },
+          },
+        },
+      },
+    },
+    {
+      data: {
+        repository: {
+          pullRequests: {
+            nodes: [pr(1400, 'HIP/hip-1400.md')],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+  ];
+  const fetchImpl = async (_url, options) => {
+    requests.push(JSON.parse(options.body));
+    return { ok: true, status: 200, json: async () => pages.shift() };
+  };
+
+  const drafts = await fetchOpenDraftPullRequests({ token: 'token', fetchImpl });
+
+  assert.deepEqual(drafts.map(({ number }) => number), [1500, 1400]);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].variables.cursor, null);
+  assert.equal(requests[1].variables.cursor, 'page-2');
+  assert.match(requests[0].query, /after: \$cursor/);
+});
+
+test('fetchOpenDraftPullRequests rejects broken pagination cursors', async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: {
+        repository: {
+          pullRequests: {
+            nodes: [],
+            pageInfo: { hasNextPage: true, endCursor: null },
+          },
+        },
+      },
+    }),
+  });
+
+  await assert.rejects(
+    fetchOpenDraftPullRequests({ token: 'token', fetchImpl }),
+    /invalid cursor/,
+  );
+});

--- a/site/scripts/static-pages.js
+++ b/site/scripts/static-pages.js
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import path from 'path';
+import { DEFAULT_SITE_URL } from './ai-artifacts.js';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeSiteUrl(value) {
+  return String(value || DEFAULT_SITE_URL).replace(/\/+$/, '');
+}
+
+function plainDescription(hip) {
+  const text = String(hip.content || '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/[#>*_`\[\]()!-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return (text || `${hip.title} — Hiero Improvement Proposal.`).slice(0, 240);
+}
+
+function metadataRows(hip) {
+  const fields = [
+    ['HIP', hip.hip],
+    ['Status', hip.status],
+    ['Type', hip.type],
+    ['Category', hip.category],
+    ['Author', hip.author],
+    ['Created', hip.created],
+    ['Updated', hip.updated],
+  ];
+  return fields
+    .filter(([, value]) => value !== '' && value !== null && value !== undefined)
+    .map(([label, value]) => `<tr><th>${escapeHtml(label)}</th><td>${escapeHtml(value)}</td></tr>`)
+    .join('');
+}
+
+export function renderStaticHipPage(template, hip, markdown, { siteUrl = DEFAULT_SITE_URL } = {}) {
+  const canonicalSite = normalizeSiteUrl(siteUrl);
+  const canonical = `${canonicalSite}/hip/hip-${hip.hip}`;
+  const markdownUrl = `${canonical}.md`;
+  const jsonUrl = `${canonicalSite}/api/hips/${hip.hip}.json`;
+  const sourceUrl = hip.source?.url || hip.urls?.repository || '';
+  const discussionUrl = hip.urls?.discussion || sourceUrl || canonicalSite;
+  const title = `HIP-${hip.hip}: ${hip.title}`;
+  const description = plainDescription(hip);
+  const sourceLabel = hip.isDraft
+    ? 'Open pull request draft — not an adopted specification.'
+    : `Merged proposal${hip.status ? ` · ${hip.status}` : ''}.`;
+  const sourceLink = sourceUrl
+    ? ` <a href="${escapeHtml(sourceUrl)}">View canonical source.</a>`
+    : '';
+  const articleJsonLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: title,
+    description,
+    url: canonical,
+    dateCreated: hip.created || undefined,
+    dateModified: hip.updated || undefined,
+    author: hip.author ? { '@type': 'Person', name: hip.author } : undefined,
+    creativeWorkStatus: hip.isDraft ? 'Draft' : hip.status || undefined,
+    isPartOf: {
+      '@type': 'CollectionPage',
+      name: 'Hiero Improvement Proposals',
+      url: `${canonicalSite}/`,
+    },
+    sameAs: sourceUrl || undefined,
+  }).replace(/</g, '\\u003c');
+
+  const html = template
+    .replace('<title>Hiero Improvement Proposals</title>', `<title>${escapeHtml(title)}</title>`)
+    .replace(
+      '<meta name="description" content="Browse, search, and filter all Hiero Improvement Proposals.">',
+      `<meta name="description" content="${escapeHtml(description)}">`,
+    )
+    .replace(
+      '<meta property="og:title" content="Hiero Improvement Proposals">',
+      `<meta property="og:title" content="${escapeHtml(title)}">`,
+    )
+    .replace(
+      '<meta property="og:description" content="Browse, search, and filter all Hiero Improvement Proposals.">',
+      `<meta property="og:description" content="${escapeHtml(description)}">`,
+    )
+    .replace('</head>', [
+      `  <link rel="canonical" href="${escapeHtml(canonical)}">`,
+      `  <link rel="alternate" type="text/markdown" href="${escapeHtml(markdownUrl)}" title="${escapeHtml(title)} as Markdown">`,
+      `  <link rel="alternate" type="application/json" href="${escapeHtml(jsonUrl)}" title="${escapeHtml(title)} as JSON">`,
+      `  <script type="application/ld+json">${articleJsonLd}</script>`,
+      '</head>',
+    ].join('\n'))
+    .replace('<div id="list-view">', '<div id="list-view" class="hidden">')
+    .replace('<div id="detail-view" class="hidden">', '<div id="detail-view">')
+    .replace('<h1 id="hip-title"></h1>', `<h1 id="hip-title">${escapeHtml(title)}</h1>`)
+    .replace(
+      '<table class="meta-table" id="hip-meta-table"><tbody></tbody></table>',
+      `<table class="meta-table" id="hip-meta-table"><tbody>${metadataRows(hip)}</tbody></table>`,
+    )
+    .replace(
+      '<article id="hip-content"></article>',
+      `<article id="hip-content"><p class="static-source-notice"><strong>${escapeHtml(sourceLabel)}</strong>${sourceLink}</p><pre class="static-hip-markdown">${escapeHtml(markdown)}</pre></article>`,
+    )
+    .replace('id="suggest-edit" href="#"', `id="suggest-edit" href="${escapeHtml(sourceUrl || canonicalSite)}"`)
+    .replace('id="discuss-link" href="#"', `id="discuss-link" href="${escapeHtml(discussionUrl)}"`);
+
+  return html;
+}
+
+export function writeStaticHipPages({ distDir, siteUrl = DEFAULT_SITE_URL }) {
+  const templatePath = path.join(distDir, 'index.html');
+  const catalogPath = path.join(distDir, 'api', 'hips.json');
+  if (!fs.existsSync(templatePath) || !fs.existsSync(catalogPath)) return 0;
+
+  const template = fs.readFileSync(templatePath, 'utf8');
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+  let written = 0;
+
+  for (const hip of catalog.hips || []) {
+    const markdownPath = path.join(distDir, 'hip', `hip-${hip.hip}.md`);
+    if (!fs.existsSync(markdownPath)) continue;
+
+    const outputDir = path.join(distDir, 'hip', `hip-${hip.hip}`);
+    const markdown = fs.readFileSync(markdownPath, 'utf8');
+    const html = renderStaticHipPage(template, hip, markdown, { siteUrl });
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(path.join(distDir, 'hip', `hip-${hip.hip}.html`), html, 'utf8');
+    fs.writeFileSync(path.join(outputDir, 'index.html'), html, 'utf8');
+    written++;
+  }
+
+  return written;
+}

--- a/site/scripts/static-pages.test.js
+++ b/site/scripts/static-pages.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { renderStaticHipPage, writeStaticHipPages } from './static-pages.js';
+
+const template = `<!doctype html>
+<html><head>
+<title>Hiero Improvement Proposals</title>
+<meta name="description" content="Browse, search, and filter all Hiero Improvement Proposals.">
+<meta property="og:title" content="Hiero Improvement Proposals">
+<meta property="og:description" content="Browse, search, and filter all Hiero Improvement Proposals.">
+</head><body>
+<div id="list-view"></div>
+<div id="detail-view" class="hidden">
+<h1 id="hip-title"></h1>
+<a id="suggest-edit" href="#">Edit</a>
+<a id="discuss-link" href="#">Discuss</a>
+<table class="meta-table" id="hip-meta-table"><tbody></tbody></table>
+<article id="hip-content"></article>
+</div>
+</body></html>`;
+
+const draft = {
+  hip: 1500,
+  title: 'A draft <proposal>',
+  status: 'Draft',
+  type: 'Standards Track',
+  category: 'Service',
+  author: 'A. Author',
+  created: '2026-04-29',
+  updated: '2026-06-22',
+  isDraft: true,
+  content: '## Abstract\nUseful summary.',
+  source: { url: 'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1500' },
+  urls: { discussion: 'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/1500' },
+};
+
+test('renderStaticHipPage embeds escaped full content and machine-readable alternates', () => {
+  const html = renderStaticHipPage(template, draft, '---\nhip: 1500\n---\n<script>alert(1)</script>');
+
+  assert.match(html, /<title>HIP-1500: A draft &lt;proposal&gt;<\/title>/);
+  assert.match(html, /<div id="list-view" class="hidden">/);
+  assert.match(html, /<div id="detail-view">/);
+  assert.match(html, /Open pull request draft — not an adopted specification/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /rel="canonical" href="https:\/\/hips\.hedera\.com\/hip\/hip-1500"/);
+  assert.match(html, /type="text\/markdown" href="https:\/\/hips\.hedera\.com\/hip\/hip-1500\.md"/);
+  assert.match(html, /id="discuss-link" href="https:\/\/github\.com\/hiero-ledger\/hiero-improvement-proposals\/pull\/1500"/);
+});
+
+test('writeStaticHipPages creates a progressive HTML page for every catalog entry', () => {
+  const distDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hips-static-pages-'));
+  fs.mkdirSync(path.join(distDir, 'api'), { recursive: true });
+  fs.mkdirSync(path.join(distDir, 'hip'), { recursive: true });
+  fs.writeFileSync(path.join(distDir, 'index.html'), template);
+  fs.writeFileSync(path.join(distDir, 'api', 'hips.json'), JSON.stringify({ hips: [draft] }));
+  fs.writeFileSync(path.join(distDir, 'hip', 'hip-1500.md'), 'Full draft content');
+
+  const count = writeStaticHipPages({ distDir });
+
+  assert.equal(count, 1);
+  const output = fs.readFileSync(path.join(distDir, 'hip', 'hip-1500', 'index.html'), 'utf8');
+  const cleanUrlTarget = fs.readFileSync(path.join(distDir, 'hip', 'hip-1500.html'), 'utf8');
+  assert.match(output, /Full draft content/);
+  assert.match(output, /HIP-1500/);
+  assert.equal(cleanUrlTarget, output);
+});

--- a/site/src/main.js
+++ b/site/src/main.js
@@ -204,9 +204,9 @@ let sectionSorts = new Map();
 async function init() {
   // Support old /hip/hip-NNN paths — GitHub Pages serves 404.html (= index.html)
   // for unknown paths, so the SPA loads and we route based on the pathname.
-  const pathMatch = window.location.pathname.match(/\/hip\/hip-(\d+)$/);
+  const pathMatch = window.location.pathname.match(/\/hip\/hip-(\d+)\/?$/);
   if (pathMatch && !window.location.hash) {
-    history.replaceState(null, '', window.location.pathname.replace(/\/hip\/hip-\d+$/, '') + '#hip-' + pathMatch[1]);
+    history.replaceState(null, '', window.location.pathname.replace(/\/hip\/hip-\d+\/?$/, '') + '#hip-' + pathMatch[1]);
   }
 
   initTheme();

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -654,6 +654,27 @@ main {
   word-break: break-word;
 }
 
+/* Build-time fallback shown until the SPA enhances a direct HIP URL. It keeps
+   the complete document readable to clients that do not execute JavaScript. */
+.static-source-notice {
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  color: var(--fg-muted);
+}
+
+.static-hip-markdown {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font: inherit;
+  line-height: 1.65;
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
 /* Reactions bar */
 .reactions-bar {
   display: flex;

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -1,15 +1,21 @@
 import { defineConfig } from 'vite';
 import fs from 'fs';
 import path from 'path';
+import { writeStaticHipPages } from './scripts/static-pages.js';
 
-// Copy index.html → 404.html so GitHub Pages serves the SPA for all paths
-// (e.g. /hip/hip-1341). The app reads the pathname and routes internally.
-function copy404Plugin() {
+// Keep the SPA fallback while also writing progressively rendered HIP pages.
+// Direct HIP URLs therefore contain the proposal before JavaScript executes.
+function staticHipPagesPlugin() {
   return {
-    name: 'copy-404',
+    name: 'static-hip-pages',
     closeBundle() {
       const dist = path.resolve(import.meta.dirname, 'dist');
       fs.copyFileSync(path.join(dist, 'index.html'), path.join(dist, '404.html'));
+      const count = writeStaticHipPages({
+        distDir: dist,
+        siteUrl: process.env.SITE_URL,
+      });
+      console.log(`Generated ${count} progressively rendered HIP pages`);
     },
   };
 }
@@ -18,5 +24,5 @@ export default defineConfig({
   root: '.',
   publicDir: 'public',
   base: process.env.VITE_BASE || '/',
-  plugins: [copy404Plugin()],
+  plugins: [staticHipPagesPlugin()],
 });


### PR DESCRIPTION
## What changed

- Generate `/llms.txt`, `/llms-full.txt`, stable metadata/full-content JSON catalogs, and one Markdown document per HIP.
- Progressively render every normal `/hip/hip-{number}` URL so the initial HTML contains the complete escaped proposal before JavaScript runs.
- Include merged HIPs and open-PR drafts with explicit provenance, commit SHA, source path, and an `isDraft` warning.
- Paginate through every open GitHub pull request instead of stopping at the first 100.
- Publish crawler discovery, structured data, CORS/cache headers, canonical/alternate links, and Netlify clean-URL routing.
- Keep the authenticated data build in a single deploy step so fresh draft content is not overwritten by a second tokenless build.

## Why

The current site is a client-rendered SPA. Fetchers that do not execute JavaScript receive the shell but not the HIP body, which made documents such as the unmerged HIP-1500 appear unavailable. The draft feed also queried only the first GraphQL page, and the Pages workflow rebuilt data a second time without `GITHUB_TOKEN`.

## Impact

LLMs and search crawlers can now retrieve a shared HIP URL directly, discover the full corpus from `llms.txt` or the sitemap, or download compact/full structured data without executing JavaScript. Human visitors keep the existing interactive experience after progressive enhancement. Open-PR content is clearly labeled as unmerged and pinned to its source commit.

## Validation

- `npm test` — 12/12 tests pass, including property tests, pagination, output generation, provenance, and escaped static HTML.
- `npm run build` — production build succeeds and generates 172 progressive pages in the current fixture build (157 merged + 15 open-PR drafts).
- Verified HIP-1500 in direct HTML, Markdown, individual JSON, full JSON, `llms.txt`, `llms-full.txt`, and the sitemap.
- Verified HTTP 200 and appropriate MIME types for generated HTML, Markdown, JSON, text, XML, and robots resources.
- Commit includes a DCO `Signed-off-by` trailer and a locally verified GPG signature.
