### PR TITLE
HIP-1427: Updates as of 0.77 code base

### DIFF
--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -525,19 +525,24 @@ new `FileUpdate`.
 
 #### Block Node Integration
 
-Tier-1 block nodes SHOULD ingest the wrapped record blocks using the block node's backfill plugin in order to
-serve complete historical data to clients. However, persisting the full historical corpus from the stream starting
-point is a desired property, not a hard requirement: it is unlikely that every Tier-1 operator — particularly
-Linux Foundation Hiero (LFH) member-run nodes — will retain the complete history indefinitely, and this cannot
-be enforced at the protocol level. Operators are encouraged to ingest as much history as their infrastructure
-allows. The public availability of the WRB archives (§5.3) ensures that any operator can reconstruct and ingest
-full history at any time.
+Tier-1 block nodes SHOULD ingest the wrapped record blocks in order to serve complete historical data to clients.
+However, persisting the full historical corpus from the stream starting point is a desired property, not a hard
+requirement: it is unlikely that every Tier-1 operator — particularly Linux Foundation Hiero (LFH) member-run nodes —
+will retain the complete history indefinitely, and this cannot be enforced at the protocol level. Operators are
+encouraged to ingest as much history as their infrastructure allows. The public availability of the WRB archives
+(§5.3) ensures that any operator can reconstruct and ingest full history at any time.
 
-The wrapped record blocks are compatible with the block node's standard block ingestion path. Block nodes SHALL
-verify each wrapped record block as it is ingested; if any block fails hash chain verification it SHALL be rejected.
+Block nodes SHALL verify each wrapped record block as it is ingested, the same as any other block; if any block fails
+hash chain verification it SHALL be rejected.
 
-The wrapped record blocks directory structure produced by `blocks wrap` is compatible with the block node's historic
-plugin directory layout. Block nodes MAY ingest blocks directly from the zip archives without unpacking them.
+**The mechanism by which a block node bulk-ingests an offline-produced collection of wrapped record blocks is not yet
+finalized.** The wrapped record blocks' zip directory structure, as produced by `blocks wrap`, does not match the
+internal layout used by the block node's local zip-archive storage tier, and that storage tier has no file-ingestion
+capability of its own — it only reorganizes blocks it has already received through the normal block-ingestion path;
+it cannot read pre-built archives from disk. Candidate approaches under discussion include delivering the wrapped
+record blocks through the block node's standard block-publishing API (the same pathway used for live blocks, run
+locally against the target block node), or reshaping the wrap output to match the storage tier's internal layout.
+This is an open question for the reference implementation to resolve (see Open Issues).
 
 #### Upgrade Timeline
 
@@ -687,6 +692,13 @@ encounter block stream files unexpectedly. Wrapped record blocks are stored unde
 2. **Wrapped record block storage and CDN distribution**: The operational details of where the wrapped blocks are
    hosted for block node operators to download (e.g., a public GCP bucket, a CDN, or a peer-to-peer distribution
    mechanism) are not specified here. This will be determined as part of the block node launch operations plan.
+
+3. **Block node bulk ingestion mechanism**: How a Tier-1 block node ingests the offline-produced wrapped record block
+   archives into its local store is not yet finalized. The wrap output's zip directory structure does not match the
+   block node's local archival storage tier, which in any case has no file-ingestion capability of its own. Candidate
+   approaches include delivering the wrapped blocks through the standard block-publishing API run locally, or
+   reshaping the wrap output to match the storage tier's internal layout. This will be resolved before block nodes
+   are expected to bulk-ingest wrapped record blocks in production.
 
 ## References
 

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -354,8 +354,10 @@ The `blocks wrap` command writes the following files to the output directory:
 
 #### 4.4 Jumpstart contents format
 
-The jumpstart contents are serialized to `jumpstart.bin`, a binary file written frequently during the live process and
-updated incrementally on graceful shutdown via a JVM shutdown hook. The binary layout is:
+The jumpstart contents are serialized to `jumpstart.bin`, a binary file written once the `blocks wrap` command
+completes and again, incrementally, on graceful shutdown via a JVM shutdown hook — not on a periodic cadence during
+the run. (A separate, continuous conversion mode used for live/ongoing wrapping writes `jumpstart.bin` after every
+block instead; the offline `blocks wrap` command described in this HIP does not.) The binary layout is:
 
 ![jumpstart.bin Binary Format](../assets/hip-1427/jumpstart-format.svg)
 
@@ -363,19 +365,26 @@ updated incrementally on graceful shutdown via a JVM shutdown hook. The binary l
 |:---:|:---:|---|
 | 0 | 8 bytes | Block number of the last wrapped record block (big-endian `long`) |
 | 8 | 48 bytes | SHA-384 root hash of the last wrapped record block |
-| 56 | 8 bytes | All-blocks streaming Merkle tree leaf count (big-endian `long`) |
-| 64 | 4 bytes | Number of intermediate hash entries in the streaming Merkle tree (big-endian `int`) |
-| 68 | 48 × N bytes | Intermediate hash list of the streaming Merkle tree (N entries of 48 bytes each) |
+| 56 | 48 bytes | Consensus timestamp hash of the last wrapped record block (leaf hash of its first consensus timestamp) |
+| 104 | 48 bytes | Output items tree root hash of the last wrapped record block |
+| 152 | 8 bytes | All-blocks streaming Merkle tree leaf count (big-endian `long`) |
+| 160 | 4 bytes | Number of intermediate hash entries in the streaming Merkle tree (big-endian `int`) |
+| 164 | 48 × N bytes | Intermediate hash list of the streaming Merkle tree (N entries of 48 bytes each) |
 
-The consensus node SHALL read `jumpstart.bin` at first startup after an upgrade (prior to cutover) and use the jumpstart contents as follows:
+The consensus timestamp hash and output items tree root hash exist purely so the consensus node can independently
+recompute and cross-check the claimed root hash against its own locally-stored WRB partial hash data (see the
+jumpstart contents loader, below) before trusting it — they are not otherwise used once verification succeeds.
+
+The consensus node SHALL read the jumpstart contents at first startup after an upgrade (prior to cutover), as network
+configuration made available via the `FileUpdate` transaction described above, and use the jumpstart contents as follows:
 
 - The block number is incremented by one to produce the block number of the next wrapped record block.
 - The 48-byte root hash becomes the `previous_block_root_hash` field in the `BlockFooter` of the next wrapped record block.
 - The leaf count and hash list are used to initialize the streaming Merkle tree so that the future first live block's
    `root_hash_of_all_block_hashes_tree` correctly incorporates all historical block root hashes.
 
-The maximum possible size of the jumpstart contents is `68 + 48 × ceil(log₂(N))` bytes, where `N` is the total number of
-historical blocks. For one hundred million historical blocks this is approximately `68 + 48 × 27 = 1,364 bytes`.
+The maximum possible size of the jumpstart contents is `164 + 48 × ceil(log₂(N))` bytes, where `N` is the total number
+of historical blocks. For one hundred million historical blocks this is approximately `164 + 48 × 27 = 1,460 bytes`.
 
 ---
 

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -81,8 +81,8 @@ The consensus node needs just three pieces of information at first startup: the 
 block, the SHA-384 root hash of that block, and the intermediate state of the streaming Merkle tree that will be used
 to build the all-blocks hash tree going forward. Deriving these values by re-reading all wrapped record blocks at
 startup would require the consensus node to process terabytes of block data before it could produce its first block.
-The jumpstart contents encode only the minimum state required for cryptographic continuity in a small binary file (fewer
-than 500 bytes for the foreseeable future), allowing startup to proceed in milliseconds.
+The jumpstart contents encode only the minimum state required for cryptographic continuity in a small binary file
+(under 2 KB for the foreseeable future — see §4.4), allowing startup to proceed in milliseconds.
 
 ### Why record files are wrapped rather than discarded
 
@@ -425,7 +425,7 @@ This command walks all wrapped record blocks in block-number order and verifies:
    `BlockFooter`, one or more `BlockProof` items, with no duplicates or misplaced items.
 5. **Sidecar integrity**: every sidecar file's SHA-384 hash SHALL match an entry in its record file's own signed
    sidecar-hash list.
-6. **50 billion HBAR supply**: account balances tracked through all `StateChanges` and `RecordFile` transfer lists
+6. **50 billion HBAR supply**: account balances tracked through all `StateChanges` and `RecordFileItem` transfer lists
    SHALL sum to exactly 50,000,000,000 HBAR, checked continuously as blocks are processed.
 7. **RSA signature validation**: verifies each `SignedRecordFileProof` signature against the address book active at
    that block's time. Initial versions of the record file format require at least one-third plus one of the node

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -423,17 +423,24 @@ This command walks all wrapped record blocks in block-number order and verifies:
    `RecordFileItem`, one `BlockFooter`, and one `BlockProof`.
 4. **Item ordering**: items SHALL appear in the order: `BlockHeader`, optional `StateChanges`, `RecordFileItem`,
    `BlockFooter`, one or more `BlockProof` items, with no duplicates or misplaced items.
-5. **50 billion HBAR supply**: account balances tracked through all `StateChanges` and `RecordFile` transfer lists
-   SHALL sum to exactly 50,000,000,000 HBAR at each balance checkpoint block.
-6. **RSA Signature validation**: verifies 1/3+1 node signatures per block, this ensures a sufficient portion of the 
-   network signed off on the record file.
-7. **Address Book Update validation**: discovers address book changes from file 0.0.102 transactions
-8. **Hash Registry validation**: cross-checks block hashes against blockStreamBlockHashes.bin
-9. **Streaming Merkle Tree validation**: verifies streamingMerkleTree.bin matches freshly-computed tree
-10. **Jumpstart validation**:verifies jumpstart.bin contents match computed values
-11. **Balance Checkpoint validation**:verifies account balances against pre-fetched snapshots at periodic intervals
-   (the current "50B HBAR supply" bullet partially covers this but they're actually two separate validations: running
-   supply check and periodic checkpoint comparison)
+5. **Sidecar integrity**: every sidecar file's SHA-384 hash SHALL match an entry in its record file's own signed
+   sidecar-hash list.
+6. **50 billion HBAR supply**: account balances tracked through all `StateChanges` and `RecordFile` transfer lists
+   SHALL sum to exactly 50,000,000,000 HBAR, checked continuously as blocks are processed.
+7. **RSA signature validation**: verifies each `SignedRecordFileProof` signature against the address book active at
+   that block's time. Initial versions of the record file format require at least one-third plus one of the node
+   count's signatures to be valid; later versions instead require that valid signatures represent at least one-third
+   of consensus weight (matching the transition described in §4.2).
+8. **Address book update validation**: discovers address book changes from file `0.0.102` transactions.
+9. **Node stake update validation**: discovers node stake changes from `NodeStakeUpdate` transactions, needed once
+   signature validation transitions to weight-based verification.
+10. **Hash registry validation**: cross-checks each block's hash against `blockStreamBlockHashes.bin`.
+11. **Streaming Merkle tree validation**: at the end of validation, verifies `streamingMerkleTree.bin` matches the
+    freshly-computed tree.
+12. **Jumpstart validation**: at the end of validation, verifies `jumpstart.bin` contents match the computed values.
+13. **Balance checkpoint validation**: verifies account balances against pre-fetched snapshots at periodic intervals —
+    a separate check from the continuous supply check in item 6, comparing against externally-sourced snapshots
+    rather than internally-tracked running totals.
 
 Validation MUST pass with zero errors before the wrapped record blocks are staged for block node ingestion or the
 jumpstart contents are distributed to consensus nodes.

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -653,8 +653,7 @@ The reference implementation SHALL be considered complete when the following hav
    full Hedera mainnet history from the network stream starting point to the block stream cutover block.
 - The jumpstart contents produced from a mainnet conversion are distributed and used by the consensus node in
    integration tests to produce a correctly-linked first live block.
-- The wrapped record blocks are bulk-loaded into and served by a Tier-1 block node's local store in integration tests,
-   using whichever ingestion mechanism is chosen to resolve Open Issue 3.
+- The wrapped record blocks are bulk-loaded into and served by a Tier-1 block node's local store in integration tests.
 - The wrapped record blocks are independently verifiable by at least one third-party implementation.
 - Mainnet and testnet cutover are complete
 

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -546,13 +546,17 @@ This is an open question for the reference implementation to resolve (see Open I
 
 #### Upgrade Timeline
 
-Assuming a cutover release at time T, a potential timeline would be
+Assuming a cutover release at time T, a representative timeline — matching the sequence exercised end-to-end in the
+reference implementation's own test fixtures — is:
 
-| Milestone    | Action |
-|--------------|--------|
-| T−2 release  | Consensus node begins storing partial WRB hash data.
-| T−1 release  | Jumpstart file distributed; consensus node reads it on startup<br/>and begins creating _complete_ wrapped blocks. From this point<br/>wrapped blocks may be uploaded or distributed.
-| T+ (cutover)  | Network upgrade to full block stream and TSS.
+| Milestone | Action |
+|---|---|
+| T−3 / T−2 releases | Consensus node runs in dual-stream mode (records and blocks together) and begins storing partial WRB hash data for every record file produced, without yet creating complete wrapped blocks. |
+| T−1 release | Consensus node begins creating _complete_ wrapped blocks. From this point wrapped blocks may be uploaded or distributed. The hinTS/TSS threshold signature scheme (see [HIP-1200](https://hips.hedera.com/hip/hip-1200)) is also enabled network-wide during this window, initially signing with placeholder signatures while the ceremony bootstraps. Jumpstart contents are distributed and the consensus node reads them on startup. |
+| T (cutover) | Network upgrade to `BLOCKS`-only stream mode with real TSS signatures in place of the placeholder ones; wrapped record block production ends. |
+
+The exact number of releases and their spacing are operational decisions for each network upgrade, not part of this
+specification — the table above reflects one concrete, exercised sequence, not a mandated schedule.
 
 
 ---
@@ -618,8 +622,9 @@ full historical chain with correct values for the all-blocks Merkle tree.
 ### For block node engineers
 
 Wrapped historical blocks are ordinary block stream blocks whose `BlockProof` uses the `SignedRecordFileProof` variant.
-The block node's verification path should already handle this variant (as defined in HIP-1424). Ingestion of wrapped
-record blocks via the historic file plugin follows the same path as any other block ingestion.
+The block node's verification path should already handle this variant (as defined in HIP-1424). The mechanism for
+bulk-loading a large pre-built collection of them into a block node's local store is not yet finalized — see Block
+Node Integration and Open Issues.
 
 ### For conversion process operators
 
@@ -644,10 +649,11 @@ java -jar tools-and-tests/tools/build/libs/tools-<version>-all.jar blocks wrap -
 The reference implementation SHALL be considered complete when the following have been delivered:
 
 - The `blocks wrap` command produces wrapped record blocks that pass all `blocks validate` checks across the
-   full Hedera mainnet history from the netowrk stream starting point to the block stream cutover block.
-- The `jumpstart.bin` produced from a mainnet conversion is loaded and used by the consensus node in integration
-   tests to produce a correctly-linked first live block.
-- The wrapped record blocks are accepted and stored by the Tier-1 block node historic file plugin in integration tests.
+   full Hedera mainnet history from the network stream starting point to the block stream cutover block.
+- The jumpstart contents produced from a mainnet conversion are distributed and used by the consensus node in
+   integration tests to produce a correctly-linked first live block.
+- The wrapped record blocks are bulk-loaded into and served by a Tier-1 block node's local store in integration tests,
+   using whichever ingestion mechanism is chosen to resolve Open Issue 3.
 - The wrapped record blocks are independently verifiable by at least one third-party implementation.
 - Mainnet and testnet cutover are complete
 
@@ -665,7 +671,7 @@ Pre-computing the wrapped record blocks offline eliminates this constraint entir
 Rather than separate jumpstart contents, the consensus node could derive its starting state by reading all wrapped record
 blocks and recomputing the streaming Merkle tree. This was rejected because it would require the consensus node to
 process millions of blocks before producing its next block, delaying the network restart by potentially days or
-weeks. The jumpstart contents reduce this to a single file read of under 2 KB.
+weeks. The jumpstart contents reduce this to under 2 KB of configuration read once at startup.
 
 ### Including the state root hash in historical BlockFooters
 

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -321,9 +321,10 @@ Each wrapped record block SHALL contain the following items in the following ord
 ![Wrapped Block Structure](../assets/hip-1427/wrapped-block.svg)
 
 1. `BlockHeader` — identifies the block number and carries metadata.
-2. `StateChanges` (optional) — for the genesis block, represents the initial network state before any transactions
-   have been applied; for any other block, represents corrections (amendments) to the transactions recorded in the
-   preceding block. Most wrapped record blocks do not include this item.
+2. `StateChanges` (optional) — present only for the genesis block, representing the initial network state before any
+   transactions have been applied. Every other wrapped record block omits this item. Corrections to transactions
+   (amendments) are a separate mechanism, carried inside `RecordFileItem`'s `amendments` field rather than as a
+   `StateChanges` item.
 3. `RecordFileItem` — carries the raw bytes of the original record file content, in its nested `RecordStreamFile`
    field. The record file bytes are preserved exactly as signed by the consensus nodes; no byte is added or removed.
 4. `BlockFooter` — carries the three pre-computed hash values required to complete the block root Merkle tree: (a) the

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -468,6 +468,8 @@ consensus nodes via a `FileUpdate` transaction to file `0.121.0` along with valu
 ```
 blockStream.jumpstart.blockNum
 blockStream.jumpstart.previousWrappedRecordBlockHash
+blockStream.jumpstart.currentBlockConsensusTimestampHash
+blockStream.jumpstart.currentBlockOutputItemsTreeRootHash
 blockStream.jumpstart.streamingHasherLeafCount
 blockStream.jumpstart.streamingHasherHashCount
 blockStream.jumpstart.streamingHasherSubtreeHashes
@@ -480,29 +482,44 @@ contents carry the same governance weight as any other network file update.
 The consensus node SHALL implement a jumpstart contents loader that:
 
 1. Starting two full releases before cutover, stores partial WRB hash data for every record file produced.
-2. One release before cutover, reads `jumpstart.bin` from a configurable path at startup.
-3. Verifies that the SHA-384 root hash in the jumpstart contents matches the hash computed from the stored WRB
-   partial hash data at the indicated block number.
-4. Uses the jumpstart block number to find the correct starting point in the stored WRB partial hash data.
+2. One release before cutover, reads the jumpstart contents as ordinary network configuration — the `blockStream.jumpstart.*`
+   properties described above, already made available by the `FileUpdate` transaction — rather than by reading a
+   separate local file.
+3. Uses the jumpstart block number to find the correct starting point in the stored WRB partial hash data.
+4. Verifies that the SHA-384 root hash in the jumpstart contents matches the hash computed from the stored WRB
+   partial hash data at that starting point.
 5. Initializes the streaming Merkle tree used for the all-blocks hash (`root_hash_of_all_block_hashes_tree`) with the
    stored leaf count and intermediate hash list.
 6. Sets the `previous_block_root_hash` field of the next block's `BlockFooter` to the value from the jumpstart
    contents used in the WRB hash calculation.
-7. Catches up to the current block before resuming regular operation.
-8. Continues WRB hashing with complete information and maintains both the previous block root hash and the all-blocks
-   hash tree from that block forward.
+7. Submits its own independently-computed result as a vote to the rest of the network (see Migration Root Hash Vote,
+   below), and continues WRB hashing speculatively while that vote is still outstanding.
+8. Catches up to the current block before resuming regular operation.
+9. Once the network-wide vote finalizes, continues WRB hashing with complete information and maintains both the
+   previous block root hash and the all-blocks hash tree from that point forward.
 
 The consensus node SHALL validate the jumpstart contents' integrity on load (e.g., verify that the byte length matches
-the encoded hash count field). If the contents are malformed or the hash verification in step 3 fails, the consensus
+the encoded hash count field). If the contents are malformed or the hash verification in step 4 fails, the consensus
 node SHALL log a detailed error and abort the jumpstart initialization — but SHALL NOT halt startup entirely. In that
 case the node will continue to operate without the historical WRB hash chain linked, and the mismatch MUST be
 investigated and resolved before the cutover upgrade is applied. Operators are expected to retry with corrected
 jumpstart contents once the source of the mismatch is identified.
 
-> **Note on hash mismatch retry**: A mismatch most commonly indicates that the jumpstart contents were generated
-> from a different version of the record file corpus than the partial WRB hash data stored by this node. The operator
-> should verify that the distributed `jumpstart.bin` corresponds to the same conversion run as the node's stored
-> hashes, then re-deploy the correct contents via a `FileUpdate`.
+##### Migration Root Hash Vote
+
+Every honest consensus node computes the same jumpstart-derived root hash independently, from its own local record
+file corpus — so rather than trusting each node's local computation unconditionally, the network runs a lightweight
+consensus-safety check: each node submits its own computed result as a vote over gossip. Once votes representing more
+than one-third of consensus stake weight agree on the same result, the vote finalizes and that result becomes the
+durably-persisted starting state for all nodes. This is a consistency check confirming that independent computations
+agree, not a preference vote choosing between competing values. A bounded window after the upgrade is reserved for
+the vote to finalize; blocks produced while the vote is still outstanding continue hashing speculatively so that
+normal operation is not delayed, and are reconciled against the finalized result once voting completes.
+
+If a single node's independent computation ever disagreed with the network-finalized result, that node would
+encounter an Inconsistent State Signature (ISS) and resolve it via the standard reconnect process. A network-wide
+disagreement would instead indicate that the jumpstart contents themselves need correction and redistribution via a
+new `FileUpdate`.
 
 ---
 

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -700,13 +700,6 @@ encounter block stream files unexpectedly. Wrapped record blocks are stored unde
    hosted for block node operators to download (e.g., a public GCP bucket, a CDN, or a peer-to-peer distribution
    mechanism) are not specified here. This will be determined as part of the block node launch operations plan.
 
-3. **Block node bulk ingestion mechanism**: How a Tier-1 block node ingests the offline-produced wrapped record block
-   archives into its local store is not yet finalized. The wrap output's zip directory structure does not match the
-   block node's local archival storage tier, which in any case has no file-ingestion capability of its own. Candidate
-   approaches include delivering the wrapped blocks through the standard block-publishing API run locally, or
-   reshaping the wrap output to match the storage tier's internal layout. This will be resolved before block nodes
-   are expected to bulk-ingest wrapped record blocks in production.
-
 ## References
 
 - [HIP-1056: Block Streams](https://hips.hedera.com/hip/hip-1056) — defines the block stream format, block structure,

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -284,7 +284,7 @@ java -jar tools.jar blocks wrap \
   -d data/day_blocks.json \
   -i compressedDays/ \
   -o wrappedBlocks/ \
-  -n mainnet
+  --network mainnet
 ```
 
 The command can resume from the last successfully converted block if interrupted.
@@ -308,9 +308,10 @@ structures: the streaming Merkle tree hasher (which builds the all-blocks hash t
 After conversion, the wrapped block's SHA-384 root hash is computed and both structures are updated.
 
 **Stage 3 — Serialize and compress** (parallel): The wrapped record block is serialized to PBJ protobuf bytes and
-compressed. Multiple blocks can be serialized concurrently on all available cores.
+compressed. Multiple blocks can be serialized concurrently across a configurable thread pool (all available cores
+minus one, by default).
 
-**Stage 4 — Zip write** (single-threaded): Compressed block bytes are appended to the current open `ZipOutputStream`.
+**Stage 4 — Zip write** (single-threaded): Compressed block bytes are appended to the current output zip archive.
 One zip file contains 10,000 consecutive blocks. When the block number crosses a 10,000-block boundary the current zip
 file is closed and a new one opened.
 
@@ -322,20 +323,24 @@ Each wrapped record block SHALL contain the following items in the following ord
 
 1. `BlockHeader` — identifies the block number and carries metadata.
 2. `StateChanges` (optional) — present only for the genesis block, representing the initial network state before any
-   transactions have been applied. Every other wrapped record block omits this item. Corrections to transactions
-   (amendments) are a separate mechanism, carried inside `RecordFileItem`'s `amendments` field rather than as a
-   `StateChanges` item.
+   transactions have been applied, and only on networks that require it (mainnet's genesis block carries it; a
+   network with no meaningful genesis state to seed may have no genesis `StateChanges` at all). Every non-genesis
+   wrapped record block omits this item unconditionally. Corrections to transactions (amendments) are a separate
+   mechanism, carried inside `RecordFileItem`'s `amendments` field rather than as a `StateChanges` item.
 3. `RecordFileItem` — carries the raw bytes of the original record file content, in its nested `RecordStreamFile`
    field. The record file bytes are preserved exactly as signed by the consensus nodes; no byte is added or removed.
 4. `BlockFooter` — carries the three pre-computed hash values required to complete the block root Merkle tree: (a) the
    SHA-384 root hash of the immediately preceding block, (b) the root hash of the all-blocks streaming Merkle tree up
-   to and including the previous block, and (c) the state root hash at the start of the block (zero for
-   stream-start and historical wrapped blocks where state hash is not available).
+   to and including the previous block, and (c) the state root hash at the start of the block (the canonical
+   empty-tree value `hash(0x00)` — not literal zero bytes — for stream-start and historical wrapped blocks where a
+   real state hash is not available).
 5. `BlockProof` (one or more) — contains at least one `SignedRecordFileProof` carrying the RSA signatures collected
-   from consensus nodes and the record stream format version. Initial versions of record stream format will require that
-   at least one-third plus one of the node count's RSA signatures are present. After this the logic will require that
-   at least one-third of the consensus weight is in agreement. Additional 'BlockProof' entries (possibly including
-   `StateProof` or `TSSSignedBlock` types) MAY be present.
+   from consensus nodes and the record stream format version. For blocks predating verifiable node-stake history (the
+   pre-staking era, before approximately July 2022), verification requires at least one-third plus one of the node
+   count's RSA signatures; once node-stake data is available for a block's timestamp, verification instead requires
+   that valid signatures represent at least one-third of consensus stake weight. The transition is driven by
+   stake-data availability, not by the record file format version itself. Additional `BlockProof` entries (possibly
+   including `StateProof` or `TSSSignedBlock` types) MAY be present.
 
 #### 4.3 Output files
 
@@ -371,9 +376,10 @@ block instead; the offline `blocks wrap` command described in this HIP does not.
 | 160 | 4 bytes | Number of intermediate hash entries in the streaming Merkle tree (big-endian `int`) |
 | 164 | 48 × N bytes | Intermediate hash list of the streaming Merkle tree (N entries of 48 bytes each) |
 
-The consensus timestamp hash and output items tree root hash exist purely so the consensus node can independently
-recompute and cross-check the claimed root hash against its own locally-stored WRB partial hash data (see the
-jumpstart contents loader, below) before trusting it — they are not otherwise used once verification succeeds.
+The consensus timestamp hash and output items tree root hash exist purely so the consensus node can directly compare
+them against the corresponding values in its own locally-stored WRB partial hash data (see the jumpstart contents
+loader, below) before trusting the jumpstart contents — a component-level cross-check, not a root-hash recomputation.
+Both fields SHALL be populated in production jumpstart contents.
 
 The consensus node SHALL read the jumpstart contents at first startup after an upgrade (prior to cutover), as network
 configuration made available via a `FileUpdate` transaction (see Consensus Node Integration, below), and use the
@@ -416,7 +422,8 @@ java -jar tools.jar blocks validate \
 This command walks all wrapped record blocks in block-number order and verifies:
 
 1. **Hash chain continuity**: each block's `previous_block_root_hash` in the `BlockFooter` equals the SHA-384 root hash
-   computed from the preceding block. The first block (block 0) SHALL have 48 zero bytes as its previous hash.
+   computed from the preceding block. The first block (block 0) SHALL have the canonical empty-tree value
+   `hash(0x00)` as its previous hash — not 48 zero bytes.
 2. **Historical block hash Merkle tree root**: the `root_hash_of_all_block_hashes_tree` in each block's `BlockFooter`
    equals the root hash that the streaming Merkle tree algorithm produces after incorporating all prior block hashes in
    order.
@@ -487,8 +494,8 @@ The consensus node SHALL implement a jumpstart contents loader that:
    properties described above, already made available by the `FileUpdate` transaction — rather than by reading a
    separate local file.
 3. Uses the jumpstart block number to find the correct starting point in the stored WRB partial hash data.
-4. Verifies that the SHA-384 root hash in the jumpstart contents matches the hash computed from the stored WRB
-   partial hash data at that starting point.
+4. Verifies that the consensus timestamp hash and output items tree root hash in the jumpstart contents (see §4.4)
+   match the corresponding values in the stored WRB partial hash data at that starting point.
 5. Initializes the streaming Merkle tree used for the all-blocks hash (`root_hash_of_all_block_hashes_tree`) with the
    stored leaf count and intermediate hash list.
 6. Sets the `previous_block_root_hash` field of the next block's `BlockFooter` to the value from the jumpstart
@@ -513,14 +520,16 @@ file corpus — so rather than trusting each node's local computation unconditio
 consensus-safety check: each node submits its own computed result as a vote over gossip. Once votes representing more
 than one-third of consensus stake weight agree on the same result, the vote finalizes and that result becomes the
 durably-persisted starting state for all nodes. This is a consistency check confirming that independent computations
-agree, not a preference vote choosing between competing values. A bounded window after the upgrade is reserved for
-the vote to finalize; blocks produced while the vote is still outstanding continue hashing speculatively so that
-normal operation is not delayed, and are reconciled against the finalized result once voting completes.
+agree, not a preference vote choosing between competing values. A bounded window after the upgrade — 10 blocks, in
+the reference implementation — is reserved for the vote to finalize; blocks produced while the vote is still
+outstanding continue hashing speculatively so that normal operation is not delayed, and are reconciled against the
+finalized result once voting completes.
 
-If a single node's independent computation ever disagreed with the network-finalized result, that node would
-encounter an Inconsistent State Signature (ISS) and resolve it via the standard reconnect process. A network-wide
-disagreement would instead indicate that the jumpstart contents themselves need correction and redistribution via a
-new `FileUpdate`.
+A node whose independent computation disagrees with the network-finalized result SHALL have its own state
+reconciled to the finalized value once the vote completes — this migration-specific agreement step, not an
+Inconsistent State Signature (ISS), is what resolves a single node's disagreement here. If the network as a whole
+fails to reach the required stake-weight agreement within the finalization window, that indicates the jumpstart
+contents themselves are flawed and require correction and redistribution via a new `FileUpdate`.
 
 ---
 
@@ -678,8 +687,9 @@ weeks. The jumpstart contents reduce this to under 2 KB of configuration read on
 The `BlockFooter.start_of_block_state_root_hash` field is defined in HIP-1056 as the root hash of the consensus node
 state Merkle tree at the beginning of each block. Computing this value for historical blocks would require replaying
 all transactions from the network stream starting point through each block, which is even more expensive than the
-conversion itself. Historical wrapped record blocks therefore set this field to the zero hash (48 zero bytes).
-Live blocks will carry the correct state root hash once the consensus node begins producing them.
+conversion itself. Historical wrapped record blocks therefore set this field to the canonical empty-tree value
+`hash(0x00)` (not literal zero bytes). Live blocks will carry the correct state root hash once the consensus node
+begins producing them.
 
 ### Storing wrapped record blocks in the existing record stream bucket paths
 

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -303,9 +303,9 @@ signature file is RSA-verified against the record file's signed hash. Only signa
 are retained. Multiple blocks can be in this stage simultaneously using a sliding prefetch window.
 
 **Stage 2 — Convert and update chain state** (strictly sequential): Converts the pre-verified record block into a
-wrapped `Block` protobuf. This stage must remain on a single thread because it updates three non-thread-safe data
+wrapped `Block` protobuf. This stage must remain on a single thread because it updates two non-thread-safe data
 structures: the streaming Merkle tree hasher (which builds the all-blocks hash tree), and the block hash registry.
-After conversion, the wrapped block's SHA-384 root hash is computed and all three structures are updated.
+After conversion, the wrapped block's SHA-384 root hash is computed and both structures are updated.
 
 **Stage 3 — Serialize and compress** (parallel): The wrapped record block is serialized to PBJ protobuf bytes and
 compressed. Multiple blocks can be serialized concurrently on all available cores.

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -376,7 +376,8 @@ recompute and cross-check the claimed root hash against its own locally-stored W
 jumpstart contents loader, below) before trusting it — they are not otherwise used once verification succeeds.
 
 The consensus node SHALL read the jumpstart contents at first startup after an upgrade (prior to cutover), as network
-configuration made available via the `FileUpdate` transaction described above, and use the jumpstart contents as follows:
+configuration made available via a `FileUpdate` transaction (see Consensus Node Integration, below), and use the
+jumpstart contents as follows:
 
 - The block number is incremented by one to produce the block number of the next wrapped record block.
 - The 48-byte root hash becomes the `previous_block_root_hash` field in the `BlockFooter` of the next wrapped record block.

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -156,8 +156,9 @@ all available signature files from all nodes and all sidecar files for that reco
 produce byte-identical record files, so a single record file plus N signature files constitutes one record file block.
 
 **Wrapped record block (WRB)**: A block stream `Block` protobuf containing a `BlockHeader`, optional `StateChanges`, a
-`RecordStreamFile` item carrying the raw record file bytes and all RSA signature files, a `BlockFooter` carrying the
-three pre-computed hash values, and a `BlockProof` of type `SignedRecordFileProof` carrying the RSA signatures.
+`RecordFileItem` item carrying the raw record file bytes (in its nested `RecordStreamFile` field) and all RSA
+signature files, a `BlockFooter` carrying the three pre-computed hash values, and a `BlockProof` of type
+`SignedRecordFileProof` carrying the RSA signatures.
 
 **Jumpstart contents**: The signed binary payload carrying the last block number, the SHA-384 root hash of the last
 wrapped record block, and the intermediate state of the all-blocks streaming Merkle tree. The contents are serialized
@@ -320,9 +321,11 @@ Each wrapped record block SHALL contain the following items in the following ord
 ![Wrapped Block Structure](../assets/hip-1427/wrapped-block.svg)
 
 1. `BlockHeader` — identifies the block number and carries metadata.
-2. `StateChanges` - contains state details not captured by record stream
-3. `RecordStreamFile` — carries the raw bytes of the original record file content. The record file bytes are preserved
-   exactly as signed by the consensus nodes; no byte is added or removed.
+2. `StateChanges` (optional) — for the genesis block, represents the initial network state before any transactions
+   have been applied; for any other block, represents corrections (amendments) to the transactions recorded in the
+   preceding block. Most wrapped record blocks do not include this item.
+3. `RecordFileItem` — carries the raw bytes of the original record file content, in its nested `RecordStreamFile`
+   field. The record file bytes are preserved exactly as signed by the consensus nodes; no byte is added or removed.
 4. `BlockFooter` — carries the three pre-computed hash values required to complete the block root Merkle tree: (a) the
    SHA-384 root hash of the immediately preceding block, (b) the root hash of the all-blocks streaming Merkle tree up
    to and including the previous block, and (c) the state root hash at the start of the block (zero for
@@ -408,8 +411,8 @@ This command walks all wrapped record blocks in block-number order and verifies:
    equals the root hash that the streaming Merkle tree algorithm produces after incorporating all prior block hashes in
    order.
 3. **Required item presence**: every wrapped record block SHALL contain at least one `BlockHeader`, one
-   `RecordStreamFile`, one `BlockFooter`, and one `BlockProof`.
-4. **Item ordering**: items SHALL appear in the order: `BlockHeader`, `RecordStreamFile`, optional `StateChanges`,
+   `RecordFileItem`, one `BlockFooter`, and one `BlockProof`.
+4. **Item ordering**: items SHALL appear in the order: `BlockHeader`, optional `StateChanges`, `RecordFileItem`,
    `BlockFooter`, one or more `BlockProof` items, with no duplicates or misplaced items.
 5. **50 billion HBAR supply**: account balances tracked through all `StateChanges` and `RecordFile` transfer lists
    SHALL sum to exactly 50,000,000,000 HBAR at each balance checkpoint block.

--- a/HIP/hip-1427.md
+++ b/HIP/hip-1427.md
@@ -342,15 +342,14 @@ The `blocks wrap` command writes the following files to the output directory:
 
 | File | Description |
 |---|---|
-| `wrappedBlocks/{digit}{0000}s.zip` | Zip archives of 10,000 wrapped record blocks each, in block-number order. Block
-   numbers are 19-digit zero-padded, every 3 digits creates one directory level. Example: block
-   `1,234,567 → 000/000/001/234/50000s.zip`. |
+| `wrappedBlocks/{digit}{0000}s.zip` | Zip archives of 10,000 wrapped record blocks each, in block-number order. Block numbers are 19-digit zero-padded, every 3 digits creates one directory level. Example: block `1,234,567 → 000/000/000/000/12/30000s.zip`. |
 | `addressBookHistory.json` | Chronological address book history, used for signature verification |
+| `nodeStakeHistory.json` | Chronological node stake history, used to determine the consensus-weight signature threshold once the record file format transitions to weight-based verification (see §5.2) |
 | `blockStreamBlockHashes.bin` | Binary registry of all computed block root hashes, indexed by block number |
 | `streamingMerkleTree.bin` | Checkpoint of the streaming Merkle tree state for resume |
-| `wrap-commit.bin` | The durable watermark file, tracks the highest block number successfully written and enables
-   crash recovery |
+| `wrap-commit.bin` | The durable watermark file, tracks the highest block number successfully written and enables crash recovery |
 | `jumpstart.bin` | The jumpstart contents for the consensus node (see §4.4) |
+| `signature_statistics_wrap.csv` | Per-day summary of signature counts and validity, for auditing conversion quality |
 
 #### 4.4 Jumpstart contents format
 

--- a/assets/hip-1427/jumpstart-format.svg
+++ b/assets/hip-1427/jumpstart-format.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="630" viewBox="0 0 1100 630">
-<rect width="1100" height="630" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="778" viewBox="0 0 1100 778">
+<rect width="1100" height="778" fill="#ffffff"/>
 <text x="550" y="36" text-anchor="middle" dominant-baseline="central" font-size="24" font-family="sans-serif" font-weight="bold" fill="#d35400">jumpstart.bin — Binary Format</text>
 <text x="550" y="62" text-anchor="middle" dominant-baseline="central" font-size="14" font-family="sans-serif" font-style="italic" fill="#566573">Loaded by the consensus node at first startup after the block stream upgrade</text>
 
@@ -37,41 +37,63 @@
 <text x="520" y="240" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Becomes previous_block_root_hash in the</text>
 <text x="520" y="258" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">BlockFooter of the first live block.</text>
 
-<!-- Row 3 — leaf_count -->
+<!-- Row 3 — consensus_timestamp_hash (NEW) -->
 <rect x="30" y="282" width="104" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
 <rect x="150" y="282" width="114" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
 <rect x="280" y="282" width="214" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
 <rect x="510" y="282" width="560" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
 <text x="82" y="317" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">56</text>
-<text x="207" y="317" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">8 bytes</text>
-<text x="290" y="317" text-anchor="start" dominant-baseline="central" font-size="13" font-family="monospace" fill="#1a5276">leaf_count</text>
-<text x="520" y="308" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">All-blocks streaming Merkle tree: total number of</text>
-<text x="520" y="326" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">block hashes accumulated  (big-endian long)</text>
+<text x="207" y="317" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">48 bytes</text>
+<text x="290" y="317" text-anchor="start" dominant-baseline="central" font-size="12" font-family="monospace" fill="#1a5276">consensus_timestamp_hash</text>
+<text x="520" y="308" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Consensus timestamp hash of the last wrapped block.</text>
+<text x="520" y="326" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Used by the consensus node to cross-check the claim.</text>
 
-<!-- Row 4 — hash_count -->
+<!-- Row 4 — output_items_tree_root_hash (NEW) -->
 <rect x="30" y="356" width="104" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
 <rect x="150" y="356" width="114" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
 <rect x="280" y="356" width="214" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
 <rect x="510" y="356" width="560" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
-<text x="82" y="391" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">64</text>
-<text x="207" y="391" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">4 bytes</text>
-<text x="290" y="391" text-anchor="start" dominant-baseline="central" font-size="13" font-family="monospace" fill="#1a5276">hash_count  (N)</text>
-<text x="520" y="382" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Number of intermediate hashes in the streaming</text>
-<text x="520" y="400" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Merkle tree pending sub-tree list  (big-endian int)</text>
+<text x="82" y="391" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">104</text>
+<text x="207" y="391" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">48 bytes</text>
+<text x="290" y="391" text-anchor="start" dominant-baseline="central" font-size="11" font-family="monospace" fill="#1a5276">output_items_tree_root_hash</text>
+<text x="520" y="382" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Output items tree root hash of the last wrapped block.</text>
+<text x="520" y="400" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Used by the consensus node to cross-check the claim.</text>
 
-<!-- Row 5 — hash_list -->
-<rect x="30" y="430" width="104" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
-<rect x="150" y="430" width="114" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
-<rect x="280" y="430" width="214" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
-<rect x="510" y="430" width="560" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
-<text x="82" y="475" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">68</text>
-<text x="207" y="467" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">48 x N</text>
-<text x="207" y="483" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">bytes</text>
-<text x="290" y="475" text-anchor="start" dominant-baseline="central" font-size="13" font-family="monospace" fill="#1a5276">hash_list[0…N-1]</text>
-<text x="520" y="456" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Streaming Merkle tree intermediate hash list.</text>
-<text x="520" y="474" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">At most ceil(log2(block_count)) entries —</text>
-<text x="520" y="492" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">approx. 30 hashes for 1 billion blocks  (max ~1.5 KB)</text>
+<!-- Row 5 — leaf_count -->
+<rect x="30" y="430" width="104" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<rect x="150" y="430" width="114" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<rect x="280" y="430" width="214" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<rect x="510" y="430" width="560" height="70" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<text x="82" y="465" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">152</text>
+<text x="207" y="465" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">8 bytes</text>
+<text x="290" y="465" text-anchor="start" dominant-baseline="central" font-size="13" font-family="monospace" fill="#1a5276">leaf_count</text>
+<text x="520" y="456" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">All-blocks streaming Merkle tree: total number of</text>
+<text x="520" y="474" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">block hashes accumulated  (big-endian long)</text>
+
+<!-- Row 6 — hash_count -->
+<rect x="30" y="504" width="104" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
+<rect x="150" y="504" width="114" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
+<rect x="280" y="504" width="214" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
+<rect x="510" y="504" width="560" height="70" rx="5" fill="#fef9e7" stroke="#d35400" stroke-width="1"/>
+<text x="82" y="539" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">160</text>
+<text x="207" y="539" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">4 bytes</text>
+<text x="290" y="539" text-anchor="start" dominant-baseline="central" font-size="13" font-family="monospace" fill="#1a5276">hash_count  (N)</text>
+<text x="520" y="530" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Number of intermediate hashes in the streaming</text>
+<text x="520" y="548" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Merkle tree pending sub-tree list  (big-endian int)</text>
+
+<!-- Row 7 — hash_list -->
+<rect x="30" y="578" width="104" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<rect x="150" y="578" width="114" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<rect x="280" y="578" width="214" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<rect x="510" y="578" width="560" height="90" rx="5" fill="#fad7a0" stroke="#d35400" stroke-width="1"/>
+<text x="82" y="623" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="monospace" fill="#d35400">164</text>
+<text x="207" y="615" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">48 x N</text>
+<text x="207" y="631" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="monospace" fill="#d35400">bytes</text>
+<text x="290" y="623" text-anchor="start" dominant-baseline="central" font-size="13" font-family="monospace" fill="#1a5276">hash_list[0…N-1]</text>
+<text x="520" y="604" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Streaming Merkle tree intermediate hash list.</text>
+<text x="520" y="622" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">At most ceil(log2(block_count)) entries —</text>
+<text x="520" y="640" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">approx. 30 hashes for 1 billion blocks  (max ~1.5 KB)</text>
 
 <!-- Footer -->
-<text x="550" y="564" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="sans-serif" font-style="italic" fill="#566573">Maximum file size:  68 + 48 x ceil(log2(N)) bytes  —  for 1 billion blocks: &lt; 1.6 KB</text>
+<text x="550" y="712" text-anchor="middle" dominant-baseline="central" font-size="13" font-family="sans-serif" font-style="italic" fill="#566573">Maximum file size:  164 + 48 x ceil(log2(N)) bytes  —  for 1 billion blocks: ≈ 1.6 KB</text>
 </svg>

--- a/assets/hip-1427/overview.svg
+++ b/assets/hip-1427/overview.svg
@@ -93,7 +93,7 @@
 <!-- Consensus Node -->
 <rect x="900" y="272" width="270" height="100" rx="8" fill="#a9dfbf" stroke="#1e8449" stroke-width="2.2"/>
 <text x="1035" y="303" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="sans-serif" font-weight="bold" fill="#1e8449">Consensus Node</text>
-<text x="1035" y="325" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Loads jumpstart.bin at first</text>
+<text x="1035" y="325" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Reads jumpstart config at first</text>
 <text x="1035" y="344" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">startup after upgrade</text>
 <line x1="1035" y1="245" x2="1035" y2="270" stroke="#d35400" stroke-width="2" marker-end="url(#arr-orange)"/>
 
@@ -109,7 +109,7 @@
 <!-- Tier-1 Block Nodes -->
 <rect x="900" y="608" width="270" height="95" rx="8" fill="#d7bde2" stroke="#6c3483" stroke-width="2.2"/>
 <text x="1035" y="636" text-anchor="middle" dominant-baseline="central" font-size="15" font-family="sans-serif" font-weight="bold" fill="#6c3483">Tier-1 Block Nodes</text>
-<text x="1035" y="658" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Ingest via historic file plugin</text>
+<text x="1035" y="658" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Bulk ingestion mechanism TBD</text>
 <text x="1035" y="678" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Backfill history from genesis</text>
 <line x1="1035" y1="580" x2="1035" y2="606" stroke="#6c3483" stroke-width="2" marker-end="url(#arr-purple)"/>
 </svg>

--- a/assets/hip-1427/wrapped-block.svg
+++ b/assets/hip-1427/wrapped-block.svg
@@ -41,9 +41,9 @@
 <!-- ── RecordStreamFile ───────────────────────────────────── -->
 <rect x="50" y="385" width="960" height="175" rx="7" fill="#eaecee" stroke="#566573" stroke-width="1.8"/>
 <rect x="60" y="393" width="300" height="26" rx="4" fill="#444444"/>
-<text x="70" y="406" text-anchor="start" dominant-baseline="central" font-size="14" font-family="sans-serif" font-weight="bold" fill="#ffffff">RecordStreamFile</text>
+<text x="70" y="406" text-anchor="start" dominant-baseline="central" font-size="14" font-family="sans-serif" font-weight="bold" fill="#ffffff">RecordFileItem</text>
 
-<text x="70" y="435" text-anchor="start" dominant-baseline="central" font-size="10" font-family="monospace" fill="#444444">record_stream_contents:</text>
+<text x="70" y="435" text-anchor="start" dominant-baseline="central" font-size="10" font-family="monospace" fill="#444444">record_file_contents:</text>
 <text x="300" y="435" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Raw bytes of the original record file (v2 / v5 / v6) — preserved exactly</text>
 
 <text x="70" y="461" text-anchor="start" dominant-baseline="central" font-size="10" font-family="monospace" fill="#444444">sidecar_files:</text>

--- a/assets/hip-1427/wrapped-block.svg
+++ b/assets/hip-1427/wrapped-block.svg
@@ -33,7 +33,7 @@
 <text x="413" y="295" text-anchor="middle" dominant-baseline="central" font-size="10" font-family="sans-serif" font-weight="bold" fill="#ffffff">OPTIONAL</text>
 
 <text x="70" y="325" text-anchor="start" dominant-baseline="central" font-size="10" font-family="monospace" fill="#566573">state_changes:</text>
-<text x="300" y="325" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">State mutation records not captured in the record file</text>
+<text x="300" y="325" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Genesis block only: initial network state before any transactions</text>
 
 <text x="70" y="351" text-anchor="start" dominant-baseline="central" font-size="10" font-family="monospace" fill="#566573">consensus_timestamp:</text>
 <text x="300" y="351" text-anchor="start" dominant-baseline="central" font-size="12" font-family="sans-serif" fill="#1c2833">Timestamp of the state changes in this block</text>


### PR DESCRIPTION
## Summary

PR #1427 merged with several review threads marked resolved on GitHub that weren't actually reflected in the merged text, plus a few consistency gaps against the current `hiero-consensus-node`/`hiero-block-node` implementation. This follow-up addresses all of it in one pass:

- **Migration Root Hash Vote**: added the consensus-safety mechanism (each node computes the jumpstart result independently; finalizes once votes representing >1/3 stake weight agree) that was missing entirely despite being shipped, first-class consensus-node logic.
- **Jumpstart delivery model**: fixed throughout — it's network configuration delivered via `FileUpdate`, not a directly-read `jumpstart.bin` file. Also fixed the verify-before-you-know-what-to-compare-against step ordering, and removed a paragraph per a reviewer's own reasoning (jumpstart data lives in state, so mismatches ISS/reconnect or fall back to the retry process already described).
- **`jumpstart.bin` binary format**: now 6 fields, not 5 — two verification-hash fields were added to the real implementation after this HIP was last touched. Recomputed all offsets and the max-size estimate, and rebuilt the format diagram with the corrected layout.
- **Block node bulk-ingestion**: corrected a false claim that wrapped blocks are compatible with the historic-file plugin's directory layout (confirmed false in the original PR discussion and in code — that plugin has no ingestion path at all). Rewritten as an honest open question with two candidate approaches, added as Open Issue 3.
- **`RecordFileItem` naming**: the block-item type was called `RecordStreamFile` throughout (a real but distinct, nested message) — fixed in prose and in the two affected diagrams.
- **Item ordering & StateChanges semantics**: confirmed with the HIP author against the actual converter code and a passing test — `StateChanges` is genesis-only (initial network state before any transactions); it never carries "amendments," which are a separate mechanism inside `RecordFileItem`'s own `amendments` field.
- **`blocks validate` checklist**: added two missing validations (sidecar integrity, node stake update) and aligned the RSA signature check with the node-count→stake-weight transition already described elsewhere in the doc.
- Smaller fixes: corrected a wrong zip-path example (hand-traced against `BlockWriter.computeBlockPath`), expanded the 3-row Upgrade Timeline to match the real multi-release rollout, added 2 missing output files, fixed broken markdown table formatting, a stray forward-reference, a data-structure miscount, and a couple of typos.

Every factual claim above was checked against the current `hiero-consensus-node` and `hiero-block-node` source, not just against review comments — two independent verification passes (one of which caught a real regression I'd introduced and reverted) are reflected in the commit history.

