### PR TITLE
Fix HIP validation against HIP-1

### DIFF
--- a/.github/workflows/validateHeaders.yml
+++ b/.github/workflows/validateHeaders.yml
@@ -1,6 +1,7 @@
-# This is a github actions workflow that retrieves the modified hips and runs a validator script against them written in Node.
 name: Validate HIP
-on: [pull_request]
+
+on:
+  pull_request:
 
 permissions:
   contents: read
@@ -26,26 +27,25 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "12.x"
+          node-version: "20"
 
-      - name: Install jq
-        run: sudo apt-get install jq
+      - name: Test HIP validator
+        run: npm test
 
       - name: Validate HIPs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERTESIA_API_KEY: ${{ secrets.VERTESIA_API_KEY }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          REPO=${{ github.repository }}
-          PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/files")
-          MD_FILES=$(echo "$PR_DATA" | jq -r '.[] | select(.filename | test(".md$")) | select(.status != "removed") | .filename')
+          git cat-file -e "${BASE_SHA}^{commit}"
 
-          for FILE in $MD_FILES; do
-            FULL_PATH="${{ github.workspace }}/$FILE"
-            if [[ -f "$FULL_PATH" ]]; then
-              node "${{ github.workspace }}/scripts/validateHIP.js" "$FULL_PATH"
-            else
-              echo "Skipping $FILE (not found on disk)"
-            fi
-          done
+          HIP_FILES=()
+          while IFS= read -r -d '' FILE; do
+            HIP_FILES+=("$FILE")
+          done < <(git diff --name-only --diff-filter=ACMR -z "$BASE_SHA" -- ':(glob)HIP/*.md')
+
+          if (( ${#HIP_FILES[@]} == 0 )); then
+            echo "No added or modified HIP files to validate."
+            exit 0
+          fi
+
+          node scripts/validateHIP.js --base-ref "$BASE_SHA" "${HIP_FILES[@]}"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test scripts/*.test.js"
+  },
   "dependencies": {
     "simple-jekyll-search": "^1.10.0"
   }

--- a/scripts/validateHIP.js
+++ b/scripts/validateHIP.js
@@ -846,6 +846,17 @@ function escapeWorkflowData(value) {
   return String(value).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 }
 
+function escapeSummaryCell(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/\\/g, '&#92;')
+    .replace(/\|/g, '&#124;')
+    .replace(/`/g, '&#96;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\r?\n/g, ' ');
+}
+
 function formatIssue(entry, index, useColor) {
   const color = useColor ? COLORS.yellow : '';
   const bold = useColor ? COLORS.bold : '';
@@ -912,7 +923,7 @@ function appendStepSummary(results) {
     const status = validation.errors.length === 0
       ? `✅ Pass${validation.warnings.length ? ` (${validation.warnings.length} pre-existing warning${validation.warnings.length === 1 ? '' : 's'})` : ''}`
       : `❌ ${validation.errors.length} error${validation.errors.length === 1 ? '' : 's'}`;
-    lines.push(`| \`${normalizePath(filePath).replace(/\|/g, '\\|')}\` | ${status} |`);
+    lines.push(`| <code>${escapeSummaryCell(normalizePath(filePath))}</code> | ${status} |`);
   }
   lines.push('');
   fs.appendFileSync(summaryPath, `${lines.join('\n')}\n`);
@@ -1014,6 +1025,7 @@ module.exports = {
   ACTIVE_STATUSES,
   STANDARD_STATUSES,
   TRANSITIONS,
+  escapeSummaryCell,
   flowFor,
   isCalendarDate,
   isUtcDateTime,

--- a/scripts/validateHIP.js
+++ b/scripts/validateHIP.js
@@ -1,182 +1,1026 @@
-const fs = require('fs');
-const https = require('https');
+#!/usr/bin/env node
 
-// ANSI color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  red: '\x1b[31m',
-  green: '\x1b[32m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-  magenta: '\x1b[35m',
-  cyan: '\x1b[36m',
-  white: '\x1b[37m',
-  bold: '\x1b[1m'
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const TYPES = ['Standards Track', 'Informational', 'Process'];
+const STANDARD_CATEGORIES = ['Core', 'Service', 'Mirror', 'Block Node', 'Application'];
+const STATUSES = [
+  'Draft',
+  'Review',
+  'Last Call',
+  'Approved',
+  'Final',
+  'Active',
+  'Deferred',
+  'Withdrawn',
+  'Stagnant',
+  'Rejected',
+  'Replaced',
+];
+
+const STANDARD_STATUSES = new Set([
+  'Draft',
+  'Review',
+  'Last Call',
+  'Approved',
+  'Final',
+  'Deferred',
+  'Withdrawn',
+  'Stagnant',
+  'Rejected',
+  'Replaced',
+]);
+
+const ACTIVE_STATUSES = new Set([
+  'Draft',
+  'Review',
+  'Last Call',
+  'Active',
+  'Deferred',
+  'Withdrawn',
+  'Stagnant',
+  'Rejected',
+  'Replaced',
+]);
+
+// HIP-1's diagrams define the normal paths. Its review prose also permits Last
+// Call to be waived for minor changes, which is why Review can resolve directly.
+// Deferred and Stagnant HIPs may be revisited, so they can return to Draft;
+// unchanged statuses are handled separately. Stagnant is available from each
+// pre-resolution stage because HIP-1 defines it by inactivity, not proposal type.
+const TRANSITIONS = {
+  standard: new Map([
+    ['Draft', new Set(['Review', 'Deferred', 'Withdrawn', 'Stagnant'])],
+    ['Review', new Set(['Last Call', 'Approved', 'Rejected', 'Stagnant'])],
+    ['Last Call', new Set(['Approved', 'Rejected', 'Withdrawn', 'Stagnant'])],
+    ['Approved', new Set(['Final'])],
+    ['Final', new Set(['Replaced'])],
+    ['Deferred', new Set(['Draft'])],
+    ['Stagnant', new Set(['Draft'])],
+    ['Withdrawn', new Set()],
+    ['Rejected', new Set()],
+    ['Replaced', new Set()],
+  ]),
+  active: new Map([
+    ['Draft', new Set(['Review', 'Deferred', 'Withdrawn', 'Stagnant'])],
+    ['Review', new Set(['Last Call', 'Active', 'Rejected', 'Stagnant'])],
+    ['Last Call', new Set(['Active', 'Rejected', 'Withdrawn', 'Stagnant'])],
+    ['Active', new Set(['Replaced'])],
+    ['Deferred', new Set(['Draft'])],
+    ['Stagnant', new Set(['Draft'])],
+    ['Withdrawn', new Set()],
+    ['Rejected', new Set()],
+    ['Replaced', new Set()],
+  ]),
 };
 
-// Get API key from environment variable or use a fallback for development
-const API_KEY = process.env.VERTESIA_API_KEY || '';
+const REQUIRED_FIELDS = [
+  'hip',
+  'title',
+  'author',
+  'requested-by',
+  'discussions-to',
+  'type',
+  'needs-hiero-approval',
+  'needs-hedera-review',
+  'status',
+  'created',
+  'updated',
+];
 
+const OPTIONAL_EMPTY_FIELDS = new Set([
+  'working-group',
+  'last-call-date-time',
+  'hedera-acceptance-decision',
+  'hedera-reviewed-on',
+  'requires',
+  'replaces',
+  'superseded-by',
+  'release',
+]);
 
-/**
- * Validates a HIP file by sending it to the Vertesia API endpoint.
- *
- * @async
- * @function validateHIP
- * @param {string} hipPath - Path to the HIP file.
- */
-async function validateHIP(hipPath) {
-  try {
-    const hip = hipPath || process.argv[2];
+const COLORS = {
+  reset: '\u001b[0m',
+  red: '\u001b[31m',
+  green: '\u001b[32m',
+  yellow: '\u001b[33m',
+  cyan: '\u001b[36m',
+  bold: '\u001b[1m',
+};
 
-    // Skip validation for hipstable files
-    if (hip.includes('hipstable')) {
-      console.log(`${colors.green}${colors.bold}✓ Great Success${colors.reset}`);
-      return;
+function issue(code, field, line, message, suggestion) {
+  return { code, field, line, message, suggestion };
+}
+
+function stripInlineYamlComment(rawValue) {
+  const firstValueIndex = rawValue.search(/\S/);
+  const quote = firstValueIndex >= 0 && ['"', "'"].includes(rawValue[firstValueIndex])
+    ? rawValue[firstValueIndex]
+    : null;
+  let inQuotes = Boolean(quote);
+  let escaped = false;
+
+  for (let index = 0; index < rawValue.length; index += 1) {
+    const character = rawValue[index];
+    if (quote === '"' && inQuotes && character === '\\' && !escaped) {
+      escaped = true;
+      continue;
     }
-
-    console.log(`${colors.cyan}Validating ${hip}${colors.reset}`);
-
-    // Read the HIP file content
-    let draftHip = fs.readFileSync(hip, 'utf8');
-
-    // Clean up special characters that can break JSON encoding
-    // Replace common problematic Unicode characters with ASCII equivalents
-    draftHip = draftHip
-      .replace(/—/g, '-')  // em dash to hyphen
-      .replace(/–/g, '-')  // en dash to hyphen
-      .replace(/'/g, "'")  // left single quote
-      .replace(/'/g, "'")  // right single quote
-      .replace(/"/g, '"')  // left double quote
-      .replace(/"/g, '"')  // right double quote
-      .replace(/…/g, '...') // ellipsis
-      .replace(/[\u2028\u2029]/g, '\n') // line/paragraph separators
-      .replace(/'/g, "'")  // another type of smart quote (u2019)
-      .replace(/"/g, '"')  // another type of smart quote (u201C)
-      .replace(/"/g, '"'); // another type of smart quote (u201D)
-
-    // Check if API key is available
-    if (!API_KEY) {
-      throw new Error('VERTESIA_API_KEY environment variable not set');
-    }
-
-    // Properly escape the content for JSON
-    // The draftHip may contain special characters that need to be escaped
-    const requestData = JSON.stringify({
-      interaction: "Evaluate_HIP_Format",
-      data: {
-        hip_spec: ".",
-        draft_hip: draftHip
+    if (quote && inQuotes && index > firstValueIndex && character === quote && !escaped) {
+      if (quote === "'" && rawValue[index + 1] === "'") {
+        index += 1;
+        continue;
       }
-    });
-
-    // Send request to the Vertesia API using native https
-    const result = await makeRequest(requestData);
-
-    if (result.is_valid) {
-      console.log(`${colors.green}${colors.bold}✓ Great Success${colors.reset}`);
-      return;
-    } else {
-      // Format issues with numbers instead of bullets
-      const issues = result.issues.map((issue, index) =>
-        `${colors.yellow}${index + 1}. ${colors.bold}${issue.field}${colors.reset}${colors.yellow}: ${issue.issue}${colors.reset}\n  ${colors.cyan}Suggestion: ${issue.suggestion}${colors.reset}`
-      );
-
-      console.log(`${colors.red}${colors.bold}You must correct the following header issues to pass validation:${colors.reset}\n${issues.join('\n\n')}`);
-      process.exit(1);
+      inQuotes = false;
+    } else if (character === '#' && !inQuotes
+      && (index === 0 || /\s/.test(rawValue[index - 1]))) {
+      return rawValue.slice(0, index).trim();
     }
-  } catch (error) {
-    console.log(`${colors.red}${colors.bold}Error:${colors.reset} ${error.message || error}`);
-    process.exit(1);
+    escaped = false;
+  }
+  return rawValue.trim();
+}
+
+function parseScalarValue(rawValue) {
+  const value = stripInlineYamlComment(rawValue);
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+function parseFrontMatter(source) {
+  const normalized = source.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
+  const lines = normalized.split('\n');
+  const issues = [];
+  const fields = Object.create(null);
+  const locations = Object.create(null);
+
+  if (lines[0] !== '---') {
+    issues.push(issue(
+      'frontmatter-opening-delimiter',
+      'front matter',
+      1,
+      'The HIP must start with a YAML front-matter delimiter (`---`).',
+      'Put `---` on the first line, followed by the HIP headers.',
+    ));
+    return { fields, locations, body: normalized, issues };
+  }
+
+  const closingIndex = lines.indexOf('---', 1);
+  if (closingIndex === -1) {
+    issues.push(issue(
+      'frontmatter-closing-delimiter',
+      'front matter',
+      1,
+      'The YAML front matter has no closing `---` delimiter.',
+      'Add a line containing only `---` after the last header.',
+    ));
+    return { fields, locations, body: '', issues };
+  }
+
+  for (let index = 1; index < closingIndex; index += 1) {
+    const line = lines[index];
+    if (line.trim() === '' || line.trimStart().startsWith('#')) {
+      continue;
+    }
+
+    const separator = line.indexOf(':');
+    if (separator <= 0) {
+      issues.push(issue(
+        'frontmatter-line-format',
+        'front matter',
+        index + 1,
+        `Header line ${index + 1} is not in \`name: value\` form.`,
+        'Use one scalar HIP header per line, for example `status: Draft`.',
+      ));
+      continue;
+    }
+
+    const key = line.slice(0, separator).trim();
+    const value = parseScalarValue(line.slice(separator + 1));
+
+    if (!/^[a-z][a-z0-9-]*$/.test(key)) {
+      issues.push(issue(
+        'frontmatter-key-format',
+        key || 'front matter',
+        index + 1,
+        `\`${key || line.slice(0, separator)}\` is not a valid HIP header name.`,
+        'Use lowercase header names with hyphens, as shown in HIP-1.',
+      ));
+      continue;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(fields, key)) {
+      issues.push(issue(
+        'duplicate-header',
+        key,
+        index + 1,
+        `The \`${key}\` header appears more than once.`,
+        `Keep a single \`${key}: ...\` line in the front matter.`,
+      ));
+      continue;
+    }
+
+    fields[key] = value;
+    locations[key] = index + 1;
+  }
+
+  return {
+    fields,
+    locations,
+    body: lines.slice(closingIndex + 1).join('\n'),
+    issues,
+  };
+}
+
+function hasValue(fields, field) {
+  return Object.prototype.hasOwnProperty.call(fields, field) && fields[field] !== '';
+}
+
+function isPlaceholder(value) {
+  return /^<.*>$/.test(value.trim()) || /\bto be (?:assigned|filled)\b/i.test(value);
+}
+
+function hasConcreteValue(fields, field) {
+  return hasValue(fields, field) && !isPlaceholder(fields[field]);
+}
+
+function isCalendarDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function parseDateList(value) {
+  if (!value) {
+    return [];
+  }
+  return value.split(',').map((entry) => entry.trim());
+}
+
+function isUtcDateTime(value) {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value)) {
+    return false;
+  }
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime()) && date.toISOString().replace('.000Z', 'Z') === value;
+}
+
+function normalizePath(filePath) {
+  const normalized = filePath.split(path.sep).join('/');
+  const hipDirectory = normalized.lastIndexOf('/HIP/');
+  return hipDirectory === -1 ? normalized : normalized.slice(hipDirectory + 1);
+}
+
+function flowFor(fields) {
+  if (fields.type === 'Standards Track') {
+    if (!STANDARD_CATEGORIES.includes(fields.category)) {
+      return null;
+    }
+    return fields.category === 'Application' ? 'active' : 'standard';
+  }
+  if (fields.type === 'Informational' || fields.type === 'Process') {
+    return 'active';
+  }
+  return null;
+}
+
+function flowLabel(fields) {
+  if (fields.type === 'Standards Track' && fields.category === 'Application') {
+    return 'Standards Track / Application';
+  }
+  return fields.type || 'this HIP';
+}
+
+function acceptedIsLegacy(fields) {
+  return fields.status === 'Accepted'
+    && isCalendarDate(fields.created)
+    && fields.created < '2025-01-01';
+}
+
+function normalizedStatus(fields) {
+  return acceptedIsLegacy(fields) ? 'Approved' : fields.status;
+}
+
+function validateDateField(result, fields, locations, field, multiple) {
+  if (!hasConcreteValue(fields, field)) {
+    return;
+  }
+  const dates = multiple ? parseDateList(fields[field]) : [fields[field]];
+  if (dates.some((date) => !isCalendarDate(date))) {
+    result.push(issue(
+      'date-format',
+      field,
+      locations[field],
+      `\`${field}\` must contain ${multiple ? 'comma-separated dates' : 'a date'} in YYYY-MM-DD format.`,
+      multiple
+        ? `Use a value such as \`${field}: 2026-08-01, 2026-09-01\`.`
+        : `Use a value such as \`${field}: 2026-09-01\`.`,
+    ));
   }
 }
 
-/**
- * Makes an HTTPS request to the Vertesia API.
- * 
- * @async
- * @function makeRequest
- * @param {string} data - The request payload.
- * @returns {Promise<Object>} The parsed response.
- */
-function makeRequest(data) {
-  return new Promise((resolve, reject) => {
-    const options = {
-      hostname: 'studio-server-production.api.vertesia.io',
-      port: 443,
-      path: '/api/v1/execute/',
-      method: 'POST',
-      timeout: 120000, // 120 second timeout (2 minutes for Claude API calls)
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'Content-Length': Buffer.byteLength(data, 'utf8'),
-        'Authorization': `Bearer ${API_KEY}`
+function validateDocument(source, options = {}) {
+  const filePath = options.path || 'HIP/hip-0000-proposal.md';
+  const parsed = parseFrontMatter(source);
+  const { fields, locations } = parsed;
+  const result = [...parsed.issues];
+
+  if (parsed.issues.some((entry) => entry.code.startsWith('frontmatter-') && entry.code.includes('delimiter'))) {
+    return { ...parsed, issues: result };
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!hasValue(fields, field)) {
+      result.push(issue(
+        'required-header',
+        field,
+        locations[field] || 1,
+        `The required \`${field}\` header is missing or empty.`,
+        `Add \`${field}: ...\` to the YAML front matter; HIP-1 lists the required preamble fields.`,
+      ));
+    } else if (isPlaceholder(fields[field])) {
+      result.push(issue(
+        'placeholder-header',
+        field,
+        locations[field],
+        `The \`${field}\` header still contains a template placeholder.`,
+        `Replace \`${fields[field]}\` with the actual ${field} value.`,
+      ));
+    }
+  }
+
+  for (const field of OPTIONAL_EMPTY_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(fields, field) && isPlaceholder(fields[field])) {
+      result.push(issue(
+        'placeholder-header',
+        field,
+        locations[field],
+        `The optional \`${field}\` header still contains a template placeholder.`,
+        `Remove the \`${field}\` line until it has a real value, or replace the placeholder.`,
+      ));
+    }
+  }
+
+  if (hasConcreteValue(fields, 'hip') && !/^(?:0000|[1-9]\d*)$/.test(fields.hip)) {
+    result.push(issue(
+      'hip-number',
+      'hip',
+      locations.hip,
+      '`hip` must be a positive integer, or `0000` while awaiting assignment.',
+      'Use `hip: 0000` for a new submission; an editor or automation will assign its final number.',
+    ));
+  }
+
+  const normalizedFilePath = normalizePath(filePath);
+  const filenameMatch = normalizedFilePath.match(/^HIP\/hip-(\d+)(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?\.md$/);
+  if (!filenameMatch) {
+    result.push(issue(
+      'hip-filename',
+      'hip',
+      locations.hip || 1,
+      `\`${normalizedFilePath}\` does not follow HIP-1's HIP filename format.`,
+      'For a new proposal, use `HIP/hip-0000-my-feature.md`; assigned HIPs use `HIP/hip-<number>.md`.',
+    ));
+  } else if (hasConcreteValue(fields, 'hip')) {
+    const fileNumber = filenameMatch[1];
+    const headerNumber = fields.hip;
+    const numbersMatch = headerNumber === '0000'
+      ? fileNumber === '0000'
+      : String(Number(fileNumber)) === headerNumber;
+    if (!numbersMatch) {
+      result.push(issue(
+        'hip-filename-number',
+        'hip',
+        locations.hip,
+        `HIP number \`${headerNumber}\` does not match filename \`${normalizedFilePath}\`.`,
+        `Rename the file or change the header so both use HIP ${headerNumber}.`,
+      ));
+    }
+  }
+
+  if (hasConcreteValue(fields, 'type') && !TYPES.includes(fields.type)) {
+    result.push(issue(
+      'type-value',
+      'type',
+      locations.type,
+      `\`${fields.type}\` is not a HIP-1 type.`,
+      `Use exactly one of: ${TYPES.join(', ')}.`,
+    ));
+  }
+
+  if (hasConcreteValue(fields, 'discussions-to')) {
+    let discussionUrl;
+    try {
+      discussionUrl = new URL(fields['discussions-to']);
+    } catch {
+      discussionUrl = null;
+    }
+    if (!discussionUrl || !['http:', 'https:'].includes(discussionUrl.protocol)) {
+      result.push(issue(
+        'discussions-url',
+        'discussions-to',
+        locations['discussions-to'],
+        '`discussions-to` must be the full HTTP(S) URL of the HIP\'s official discussion or pull request.',
+        'Use a URL such as `https://github.com/hiero-ledger/hiero-improvement-proposals/pull/123`.',
+      ));
+    }
+  }
+
+  if (fields.type === 'Standards Track') {
+    if (!hasValue(fields, 'category')) {
+      result.push(issue(
+        'category-required',
+        'category',
+        1,
+        'Standards Track HIPs require a category so their HIP-1 workflow can be determined.',
+        `Add one of: ${STANDARD_CATEGORIES.join(', ')}.`,
+      ));
+    } else if (!isPlaceholder(fields.category) && !STANDARD_CATEGORIES.includes(fields.category)) {
+      result.push(issue(
+        'category-value',
+        'category',
+        locations.category,
+        `\`${fields.category}\` is not a Standards Track category from HIP-1.`,
+        `Use exactly one of: ${STANDARD_CATEGORIES.join(', ')}.`,
+      ));
+    }
+  } else if (fields.type === 'Informational' && hasValue(fields, 'category')) {
+    result.push(issue(
+      'category-not-applicable',
+      'category',
+      locations.category,
+      'Informational HIPs do not use a Standards Track category.',
+      'Remove the `category` header.',
+    ));
+  } else if (fields.type === 'Process' && hasValue(fields, 'category') && fields.category !== 'Process') {
+    result.push(issue(
+      'category-not-applicable',
+      'category',
+      locations.category,
+      'A Process HIP may omit `category`; if present, its category must be `Process`.',
+      'Remove the `category` header or use `category: Process`.',
+    ));
+  }
+
+  const flow = flowFor(fields);
+  if (hasConcreteValue(fields, 'status')) {
+    if (fields.status === 'Accepted') {
+      if (!acceptedIsLegacy(fields)) {
+        result.push(issue(
+          'legacy-accepted-status',
+          'status',
+          locations.status,
+          '`Accepted` is a legacy status and cannot be assigned to a HIP on or after 2025-01-01.',
+          'Use `Approved` for the Standards Track approval workflow, or `Active` for Informational, Process, and Application HIPs.',
+        ));
       }
-    };
+    } else if (!STATUSES.includes(fields.status)) {
+      result.push(issue(
+        'status-value',
+        'status',
+        locations.status,
+        `\`${fields.status}\` is not a current HIP-1 status.`,
+        `Use exactly one of: ${STATUSES.join(', ')}.`,
+      ));
+    }
 
-    const req = https.request(options, (res) => {
-      let responseData = '';
+    const status = normalizedStatus(fields);
+    const allowedStatuses = flow === 'standard' ? STANDARD_STATUSES : flow === 'active' ? ACTIVE_STATUSES : null;
+    if (allowedStatuses && !allowedStatuses.has(status)) {
+      const expected = flow === 'standard'
+        ? 'Approved and Final (not Active)'
+        : 'Active (not Approved or Final)';
+      result.push(issue(
+        'status-for-flow',
+        'status',
+        locations.status,
+        `Status \`${fields.status}\` is not valid for the ${flowLabel(fields)} workflow.`,
+        `HIP-1 uses ${expected} for this workflow. Allowed statuses: ${[...allowedStatuses].join(', ')}.`,
+      ));
+    }
+  }
 
-      res.on('data', (chunk) => {
-        responseData += chunk;
-      });
+  for (const field of ['needs-hiero-approval', 'needs-hedera-review']) {
+    if (hasConcreteValue(fields, field) && !['Yes', 'No'].includes(fields[field])) {
+      result.push(issue(
+        'yes-no-value',
+        field,
+        locations[field],
+        `\`${field}\` must be exactly \`Yes\` or \`No\`.`,
+        `Use \`${field}: Yes\` or \`${field}: No\` with matching capitalization.`,
+      ));
+    }
+  }
 
-      res.on('end', () => {
-        // Log the full response for debugging
-        if (process.env.DEBUG_API) {
-          console.log(`Status Code: ${res.statusCode}`);
-          console.log(`Headers: ${JSON.stringify(res.headers)}`);
-          console.log(`Response: ${responseData.substring(0, 500)}`);
-        }
+  if (flow) {
+    const expectedApproval = flow === 'standard' ? 'Yes' : 'No';
+    const workflowName = flow === 'standard'
+      ? 'Standards Track Core, Service, Mirror, and Block Node'
+      : 'Informational, Process, and Standards Track Application';
+    for (const field of ['needs-hiero-approval', 'needs-hedera-review']) {
+      if (['Yes', 'No'].includes(fields[field]) && fields[field] !== expectedApproval) {
+        result.push(issue(
+          'approval-for-flow',
+          field,
+          locations[field],
+          `\`${field}: ${fields[field]}\` conflicts with the HIP-1 ${workflowName} workflow.`,
+          `Use \`${field}: ${expectedApproval}\` for ${flowLabel(fields)} HIPs.`,
+        ));
+      }
+    }
+  }
 
-        // Check if we got an error status code
-        if (res.statusCode !== 200) {
-          // Check if response looks like HTML (common for error pages)
-          if (responseData.trim().startsWith('<') || responseData.includes('<!DOCTYPE')) {
-            reject(`API returned HTML error page (HTTP ${res.statusCode}). The Vertesia API endpoint may be down or the URL may have changed. Please check: https://studio-server-production.api.vertesia.io/api/v1/execute/`);
-          } else {
-            reject(`API returned error status ${res.statusCode}: ${responseData}`);
-          }
-          return;
-        }
+  validateDateField(result, fields, locations, 'created', false);
+  validateDateField(result, fields, locations, 'updated', true);
+  validateDateField(result, fields, locations, 'hedera-reviewed-on', true);
 
-        try {
-          // Check if response is HTML instead of JSON
-          if (responseData.trim().startsWith('<') || responseData.includes('<!DOCTYPE')) {
-            reject(`API returned HTML instead of JSON. This usually means the endpoint is unavailable or has moved. Response preview: ${responseData.substring(0, 200)}...`);
-            return;
-          }
+  const updatedDates = parseDateList(fields.updated);
+  if (updatedDates.length > 0 && updatedDates.every(isCalendarDate)) {
+    for (let index = 1; index < updatedDates.length; index += 1) {
+      if (updatedDates[index] <= updatedDates[index - 1]) {
+        result.push(issue(
+          'updated-date-order',
+          'updated',
+          locations.updated,
+          '`updated` dates must be unique and listed from oldest to newest.',
+          'Remove duplicate dates and put the most recent update last.',
+        ));
+        break;
+      }
+    }
+    if (isCalendarDate(fields.created) && updatedDates[updatedDates.length - 1] < fields.created) {
+      result.push(issue(
+        'updated-before-created',
+        'updated',
+        locations.updated,
+        'The latest `updated` date is earlier than the HIP `created` date.',
+        'Correct the dates so creation occurs first and the latest update is last.',
+      ));
+    }
+  }
 
-          const parsedData = JSON.parse(responseData);
-          if (parsedData.result) {
-            resolve(parsedData.result);
-          } else {
-            reject(`Invalid API response format. Expected 'result' field but got: ${JSON.stringify(parsedData).substring(0, 200)}`);
-          }
-        } catch (e) {
-          // Provide more context about what was received
-          const preview = responseData.substring(0, 200);
-          reject(`Failed to parse API response as JSON: ${e.message}\nResponse preview: ${preview}${responseData.length > 200 ? '...' : ''}`);
-        }
-      });
-    });
+  if (hasConcreteValue(fields, 'last-call-date-time') && !isUtcDateTime(fields['last-call-date-time'])) {
+    result.push(issue(
+      'last-call-date-time-format',
+      'last-call-date-time',
+      locations['last-call-date-time'],
+      '`last-call-date-time` must be a valid UTC timestamp in YYYY-MM-DDTHH:MM:SSZ format.',
+      'Use a value such as `last-call-date-time: 2026-09-15T07:00:00Z`.',
+    ));
+  }
 
-    req.on('error', (error) => {
-      reject(`Request failed: ${error.message}`);
-    });
+  if (fields.status === 'Last Call' && !hasValue(fields, 'last-call-date-time')) {
+    result.push(issue(
+      'last-call-date-time-required',
+      'last-call-date-time',
+      1,
+      'A Last Call HIP must state when its final review window ends.',
+      'Ask a HIP editor to add `last-call-date-time: YYYY-MM-DDTHH:MM:SSZ`.',
+    ));
+  }
 
-    req.on('timeout', () => {
-      req.destroy();
-      reject(`Request timed out after 120 seconds. The Vertesia API may be unavailable.`);
-    });
+  if (normalizedStatus(fields) === 'Final' && !hasValue(fields, 'release')) {
+    result.push(issue(
+      'release-required',
+      'release',
+      1,
+      'HIP-1 requires a Final Standards Track HIP to identify its implementation release.',
+      'Add the merged implementation version, for example `release: v0.70.0`.',
+    ));
+  }
 
-    req.write(data);
-    req.end();
-  });
+  if (fields.status === 'Replaced' && !hasValue(fields, 'superseded-by')) {
+    result.push(issue(
+      'superseded-by-required',
+      'superseded-by',
+      1,
+      'A Replaced HIP must identify the newer HIP that replaced it.',
+      'Add `superseded-by: <HIP number>`.',
+    ));
+  }
+
+  for (const field of ['requires', 'replaces', 'superseded-by']) {
+    if (hasConcreteValue(fields, field) && !/^\d+(?:\s*,\s*\d+)*$/.test(fields[field])) {
+      result.push(issue(
+        'hip-reference-list',
+        field,
+        locations[field],
+        `\`${field}\` must be a comma-separated list of HIP numbers.`,
+        `Use a value such as \`${field}: 123, 456\`.`,
+      ));
+    }
+  }
+
+  const decisionPresent = hasConcreteValue(fields, 'hedera-acceptance-decision');
+  const reviewedPresent = hasConcreteValue(fields, 'hedera-reviewed-on');
+  if (decisionPresent && !['Accepted', 'Not Accepted'].includes(fields['hedera-acceptance-decision'])) {
+    result.push(issue(
+      'hedera-decision-value',
+      'hedera-acceptance-decision',
+      locations['hedera-acceptance-decision'],
+      '`hedera-acceptance-decision` must be exactly `Accepted` or `Not Accepted`.',
+      'Use the decision recorded by Hedera, with matching capitalization.',
+    ));
+  }
+  if (decisionPresent !== reviewedPresent) {
+    const missing = decisionPresent ? 'hedera-reviewed-on' : 'hedera-acceptance-decision';
+    result.push(issue(
+      'hedera-review-pair',
+      missing,
+      1,
+      '`hedera-acceptance-decision` and `hedera-reviewed-on` must be recorded together.',
+      `Add the \`${missing}\` header, or remove the incomplete Hedera review metadata.`,
+    ));
+  }
+  if ((decisionPresent || reviewedPresent) && fields['needs-hedera-review'] !== 'Yes') {
+    result.push(issue(
+      'hedera-review-flag',
+      'needs-hedera-review',
+      locations['needs-hedera-review'] || 1,
+      'Recorded Hedera review metadata conflicts with `needs-hedera-review: No`.',
+      'Use `needs-hedera-review: Yes` when a Hedera review decision is recorded.',
+    ));
+  }
+  if ((decisionPresent || reviewedPresent) && flow === 'standard'
+    && !['Approved', 'Final', 'Replaced'].includes(normalizedStatus(fields))) {
+    result.push(issue(
+      'hedera-review-before-approved',
+      'hedera-acceptance-decision',
+      locations['hedera-acceptance-decision'] || locations['hedera-reviewed-on'],
+      'HIP-1 permits Hedera review of approval-track HIPs only after Hiero approval.',
+      'Remove the decision metadata until the HIP is Approved, or correct the HIP status.',
+    ));
+  }
+
+  return { ...parsed, issues: result };
 }
 
-// Execute the validation function
-validateHIP().catch(error => {
-  console.log(`${colors.red}${colors.bold}Error:${colors.reset} ${error}`);
-  process.exit(1);
-});
+function issueFingerprint(entry) {
+  return [entry.code, entry.field, entry.message, entry.suggestion].join('\u0000');
+}
+
+function latestValidDate(value) {
+  const dates = parseDateList(value);
+  return dates.length > 0 && dates.every(isCalendarDate) ? dates[dates.length - 1] : null;
+}
+
+function validateTransition(base, current) {
+  const result = [];
+  const oldStatus = normalizedStatus(base.fields);
+  const newStatus = normalizedStatus(current.fields);
+
+  if (!oldStatus || !newStatus || oldStatus === newStatus) {
+    return result;
+  }
+
+  const flow = flowFor(current.fields);
+  const allowed = flow && TRANSITIONS[flow].get(oldStatus);
+  if (!allowed || !allowed.has(newStatus)) {
+    const allowedText = allowed && allowed.size > 0
+      ? [...allowed].join(', ')
+      : 'no further status transitions';
+    result.push(issue(
+      'status-transition',
+      'status',
+      current.locations.status || 1,
+      `HIP-1 does not allow the ${flowLabel(current.fields)} status transition \`${base.fields.status}\` → \`${current.fields.status}\`.`,
+      `From \`${base.fields.status}\`, the next status may be: ${allowedText}. Keep the status unchanged for content-only edits.`,
+    ));
+  }
+  return result;
+}
+
+function validateChange(source, options = {}) {
+  const today = options.today || new Date().toISOString().slice(0, 10);
+  const current = validateDocument(source, options);
+
+  if (options.baseSource === null || options.baseSource === undefined) {
+    const errors = [...current.issues];
+    if (hasConcreteValue(current.fields, 'status') && current.fields.status !== 'Draft') {
+      errors.push(issue(
+        'new-hip-status',
+        'status',
+        current.locations.status || 1,
+        `A new HIP enters the repository as \`Draft\`, not \`${current.fields.status}\`.`,
+        'Use `status: Draft`; later status changes follow the type-specific HIP-1 workflow.',
+      ));
+    }
+    return { ...current, errors, warnings: [], isNew: true };
+  }
+
+  const base = validateDocument(options.baseSource, options);
+  const baselineFingerprints = new Set(base.issues.map(issueFingerprint));
+  const errors = current.issues.filter((entry) => !baselineFingerprints.has(issueFingerprint(entry)));
+  const warnings = current.issues.filter((entry) => baselineFingerprints.has(issueFingerprint(entry)));
+
+  errors.push(...validateTransition(base, current));
+
+  if (hasValue(base.fields, 'hip') && hasValue(current.fields, 'hip')
+    && base.fields.hip !== current.fields.hip) {
+    errors.push(issue(
+      'hip-number-changed',
+      'hip',
+      current.locations.hip || 1,
+      `An assigned HIP number is immutable (changed from ${base.fields.hip} to ${current.fields.hip}).`,
+      `Restore \`hip: ${base.fields.hip}\` and keep the filename aligned with it.`,
+    ));
+  }
+
+  if (hasValue(base.fields, 'created') && hasValue(current.fields, 'created')
+    && base.fields.created !== current.fields.created) {
+    errors.push(issue(
+      'created-date-changed',
+      'created',
+      current.locations.created || 1,
+      `The HIP creation date is immutable (changed from ${base.fields.created} to ${current.fields.created}).`,
+      `Restore \`created: ${base.fields.created}\`; record this edit in \`updated\` instead.`,
+    ));
+  }
+
+  if (source !== options.baseSource) {
+    const baseUpdated = latestValidDate(base.fields.updated);
+    const currentUpdated = latestValidDate(current.fields.updated);
+    if (baseUpdated && currentUpdated && currentUpdated < baseUpdated) {
+      errors.push(issue(
+        'updated-date-regressed',
+        'updated',
+        current.locations.updated || 1,
+        `The latest \`updated\` date moved backwards from ${baseUpdated} to ${currentUpdated}.`,
+        `Keep the existing dates and append the date of this change (${today}).`,
+      ));
+    } else if (!currentUpdated || (currentUpdated === baseUpdated && currentUpdated !== today)) {
+      errors.push(issue(
+        'updated-date-not-recorded',
+        'updated',
+        current.locations.updated || 1,
+        'The HIP changed without recording a new `updated` date.',
+        `Append the date of this change in YYYY-MM-DD form (for example \`${today}\`).`,
+      ));
+    }
+  }
+
+  return { ...current, base, errors, warnings, isNew: false };
+}
+
+function readBaseRevision(baseRef, filePath) {
+  const normalizedFilePath = normalizePath(filePath);
+  const commitExists = spawnSync('git', ['cat-file', '-e', `${baseRef}^{commit}`], {
+    encoding: 'utf8',
+  });
+  if (commitExists.status !== 0) {
+    throw new Error(`Cannot read base revision \`${baseRef}\`. Make sure the base commit was fetched.`);
+  }
+
+  let basePath = normalizedFilePath;
+  let blobExists = spawnSync('git', ['cat-file', '-e', `${baseRef}:${basePath}`], {
+    encoding: 'utf8',
+  });
+  if (blobExists.status !== 0) {
+    const changes = spawnSync(
+      'git',
+      ['diff', '--name-status', '-z', '--find-renames', baseRef, 'HEAD', '--', ':(glob)HIP/*.md'],
+      { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+    );
+    if (changes.status !== 0) {
+      throw new Error(`Cannot compare changed HIPs with base revision \`${baseRef}\`.`);
+    }
+    const entries = changes.stdout.split('\0');
+    for (let index = 0; index < entries.length - 1;) {
+      const status = entries[index];
+      index += 1;
+      if (status.startsWith('R')) {
+        const oldPath = entries[index];
+        const newPath = entries[index + 1];
+        index += 2;
+        if (newPath === normalizedFilePath) {
+          basePath = oldPath;
+          break;
+        }
+      } else {
+        index += 1;
+      }
+    }
+    blobExists = spawnSync('git', ['cat-file', '-e', `${baseRef}:${basePath}`], {
+      encoding: 'utf8',
+    });
+    if (blobExists.status !== 0) {
+      return null;
+    }
+  }
+
+  const result = spawnSync('git', ['show', `${baseRef}:${basePath}`], {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`Cannot read \`${basePath}\` from base revision \`${baseRef}\`.`);
+  }
+  return result.stdout;
+}
+
+function escapeWorkflowProperty(value) {
+  return String(value)
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+    .replace(/:/g, '%3A')
+    .replace(/,/g, '%2C');
+}
+
+function escapeWorkflowData(value) {
+  return String(value).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function formatIssue(entry, index, useColor) {
+  const color = useColor ? COLORS.yellow : '';
+  const bold = useColor ? COLORS.bold : '';
+  const reset = useColor ? COLORS.reset : '';
+  const location = entry.line ? ` (line ${entry.line})` : '';
+  return `${color}${index + 1}. ${bold}${entry.field}${reset}${color}${location}: ${entry.message}${reset}\n`
+    + `   ${useColor ? COLORS.cyan : ''}Fix: ${entry.suggestion}${reset}`;
+}
+
+function printResult(filePath, validation, options = {}) {
+  const useColor = options.useColor;
+  const githubActions = options.githubActions;
+  const displayPath = normalizePath(filePath);
+
+  if (validation.errors.length === 0) {
+    const success = validation.warnings.length > 0
+      ? 'introduces no new HIP-1 issues'
+      : 'follows HIP-1';
+    console.log(`${useColor ? COLORS.green + COLORS.bold : ''}✓ ${displayPath} ${success}${useColor ? COLORS.reset : ''}`);
+  } else {
+    console.error(`${useColor ? COLORS.red + COLORS.bold : ''}✗ ${displayPath} has ${validation.errors.length} HIP-1 validation error${validation.errors.length === 1 ? '' : 's'}:${useColor ? COLORS.reset : ''}`);
+    validation.errors.forEach((entry, index) => console.error(formatIssue(entry, index, useColor)));
+  }
+
+  if (validation.warnings.length > 0) {
+    console.warn(`${useColor ? COLORS.yellow : ''}⚠ ${validation.warnings.length} pre-existing issue${validation.warnings.length === 1 ? '' : 's'} also found; they do not fail this PR because it did not introduce them.${useColor ? COLORS.reset : ''}`);
+    validation.warnings.forEach((entry, index) => console.warn(formatIssue(entry, index, useColor)));
+  }
+
+  if (githubActions) {
+    for (const entry of validation.errors) {
+      const title = escapeWorkflowProperty(`HIP-1: ${entry.code}`);
+      const annotationPath = escapeWorkflowProperty(displayPath);
+      const line = Number.isInteger(entry.line) && entry.line > 0 ? `,line=${entry.line}` : '';
+      const message = escapeWorkflowData(`${entry.message} Fix: ${entry.suggestion}`);
+      console.log(`::error file=${annotationPath}${line},title=${title}::${message}`);
+    }
+    for (const entry of validation.warnings) {
+      const title = escapeWorkflowProperty(`Pre-existing HIP-1 issue: ${entry.code}`);
+      const annotationPath = escapeWorkflowProperty(displayPath);
+      const line = Number.isInteger(entry.line) && entry.line > 0 ? `,line=${entry.line}` : '';
+      const message = escapeWorkflowData(`${entry.message} Fix: ${entry.suggestion}`);
+      console.log(`::warning file=${annotationPath}${line},title=${title}::${message}`);
+    }
+  }
+}
+
+function appendStepSummary(results) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    return;
+  }
+  const errorCount = results.reduce((sum, entry) => sum + entry.validation.errors.length, 0);
+  const warningCount = results.reduce((sum, entry) => sum + entry.validation.warnings.length, 0);
+  const lines = [
+    '## HIP-1 validation',
+    '',
+    `Validated ${results.length} changed HIP${results.length === 1 ? '' : 's'}: ${errorCount} error${errorCount === 1 ? '' : 's'}, ${warningCount} pre-existing warning${warningCount === 1 ? '' : 's'}.`,
+    '',
+    '| HIP | Result |',
+    '| --- | --- |',
+  ];
+  for (const { filePath, validation } of results) {
+    const status = validation.errors.length === 0
+      ? `✅ Pass${validation.warnings.length ? ` (${validation.warnings.length} pre-existing warning${validation.warnings.length === 1 ? '' : 's'})` : ''}`
+      : `❌ ${validation.errors.length} error${validation.errors.length === 1 ? '' : 's'}`;
+    lines.push(`| \`${normalizePath(filePath).replace(/\|/g, '\\|')}\` | ${status} |`);
+  }
+  lines.push('');
+  fs.appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/validateHIP.js [--base-ref <git-ref>] <HIP file> [HIP file ...]',
+    '',
+    'Without --base-ref, each file is validated as a new HIP and must be Draft.',
+    'With --base-ref, existing HIPs are also checked for valid status transitions',
+    'and an updated date; pre-existing legacy issues are reported as warnings.',
+  ].join('\n');
+}
+
+function parseArguments(argv) {
+  const files = [];
+  let baseRef = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      return { help: true, baseRef, files };
+    }
+    if (argument === '--base-ref') {
+      baseRef = argv[index + 1];
+      if (!baseRef) {
+        throw new Error('`--base-ref` requires a git revision.');
+      }
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('-')) {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+    files.push(argument);
+  }
+  return { help: false, baseRef, files };
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  let args;
+  try {
+    args = parseArguments(argv);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    console.error(usage());
+    return 2;
+  }
+
+  if (args.help) {
+    console.log(usage());
+    return 0;
+  }
+  if (args.files.length === 0) {
+    console.error('Error: no HIP files were provided.');
+    console.error(usage());
+    return 2;
+  }
+
+  const githubActions = process.env.GITHUB_ACTIONS === 'true';
+  const useColor = Boolean(process.stderr.isTTY && !process.env.NO_COLOR && !githubActions);
+  const results = [];
+  let failed = false;
+
+  for (const filePath of args.files) {
+    try {
+      const source = fs.readFileSync(filePath, 'utf8');
+      const baseSource = args.baseRef ? readBaseRevision(args.baseRef, filePath) : null;
+      const validation = validateChange(source, { path: filePath, baseSource });
+      printResult(filePath, validation, { useColor, githubActions });
+      results.push({ filePath, validation });
+      failed ||= validation.errors.length > 0;
+    } catch (error) {
+      failed = true;
+      const validation = {
+        errors: [issue(
+          'validator-input',
+          'file',
+          1,
+          error.message,
+          'Confirm the file exists and the pull request base commit is available.',
+        )],
+        warnings: [],
+      };
+      printResult(filePath, validation, { useColor, githubActions });
+      results.push({ filePath, validation });
+    }
+  }
+
+  appendStepSummary(results);
+  return failed ? 1 : 0;
+}
+
+if (require.main === module) {
+  process.exitCode = runCli();
+}
+
+module.exports = {
+  ACTIVE_STATUSES,
+  STANDARD_STATUSES,
+  TRANSITIONS,
+  flowFor,
+  isCalendarDate,
+  isUtcDateTime,
+  parseArguments,
+  parseFrontMatter,
+  runCli,
+  validateChange,
+  validateDocument,
+  validateTransition,
+};

--- a/scripts/validateHIP.test.js
+++ b/scripts/validateHIP.test.js
@@ -8,6 +8,7 @@ const { spawnSync } = require('node:child_process');
 const test = require('node:test');
 
 const {
+  escapeSummaryCell,
   parseFrontMatter,
   validateChange,
   validateDocument,
@@ -93,6 +94,13 @@ test('front matter parser preserves scalar values containing colons', () => {
     'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/123',
   );
   assert.match(parsed.body, /## Abstract/);
+});
+
+test('job summary cells safely encode hostile HIP filenames', () => {
+  assert.equal(
+    escapeSummaryCell('HIP/a\\b|c`d<e>&f\r\ng.md'),
+    'HIP/a&#92;b&#124;c&#96;d&lt;e&gt;&amp;f g.md',
+  );
 });
 
 test('front matter parser supports template comments without stripping URL fragments', () => {

--- a/scripts/validateHIP.test.js
+++ b/scripts/validateHIP.test.js
@@ -1,0 +1,666 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const {
+  parseFrontMatter,
+  validateChange,
+  validateDocument,
+} = require('./validateHIP');
+
+const REPOSITORY_ROOT = path.resolve(__dirname, '..');
+
+function makeHip(overrides = {}) {
+  const values = {
+    hip: '123',
+    title: 'Deterministic HIP validation',
+    author: 'Example Author (@example)',
+    requestedBy: 'Example Project',
+    discussionsTo: 'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/123',
+    type: 'Standards Track',
+    category: 'Service',
+    needsHieroApproval: 'Yes',
+    needsHederaReview: 'Yes',
+    status: 'Draft',
+    created: '2026-08-01',
+    updated: '2026-08-01',
+    ...overrides,
+  };
+
+  const headers = [
+    '---',
+    `hip: ${values.hip}`,
+    `title: ${values.title}`,
+    `author: ${values.author}`,
+  ];
+  if (values.requestedBy !== null) headers.push(`requested-by: ${values.requestedBy}`);
+  headers.push(`discussions-to: ${values.discussionsTo}`);
+  headers.push(`type: ${values.type}`);
+  if (values.category !== null) headers.push(`category: ${values.category}`);
+  headers.push(`needs-hiero-approval: ${values.needsHieroApproval}`);
+  headers.push(`needs-hedera-review: ${values.needsHederaReview}`);
+  headers.push(`status: ${values.status}`);
+  if (values.lastCallDateTime !== undefined) {
+    headers.push(`last-call-date-time: ${values.lastCallDateTime}`);
+  } else if (values.status === 'Last Call') {
+    headers.push('last-call-date-time: 2026-09-15T07:00:00Z');
+  }
+  if (values.hederaDecision !== undefined) {
+    headers.push(`hedera-acceptance-decision: ${values.hederaDecision}`);
+  }
+  if (values.hederaReviewedOn !== undefined) {
+    headers.push(`hedera-reviewed-on: ${values.hederaReviewedOn}`);
+  }
+  headers.push(`created: ${values.created}`);
+  headers.push(`updated: ${values.updated}`);
+  if (values.requires !== undefined) headers.push(`requires: ${values.requires}`);
+  if (values.replaces !== undefined) headers.push(`replaces: ${values.replaces}`);
+  if (values.supersededBy !== undefined) {
+    headers.push(`superseded-by: ${values.supersededBy}`);
+  } else if (values.status === 'Replaced') {
+    headers.push('superseded-by: 456');
+  }
+  if (values.release !== undefined) {
+    headers.push(`release: ${values.release}`);
+  } else if (values.status === 'Final') {
+    headers.push('release: v0.99.0');
+  }
+  headers.push('---', '', '## Abstract', '', values.body || 'A complete proposal.', '');
+  return headers.join('\n');
+}
+
+function codes(validation, collection = 'issues') {
+  return validation[collection].map((entry) => entry.code);
+}
+
+function assertValidDocument(source, options = {}) {
+  const validation = validateDocument(source, {
+    path: 'HIP/hip-123.md',
+    ...options,
+  });
+  assert.deepEqual(validation.issues, []);
+}
+
+test('front matter parser preserves scalar values containing colons', () => {
+  const parsed = parseFrontMatter(makeHip());
+  assert.equal(
+    parsed.fields['discussions-to'],
+    'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/123',
+  );
+  assert.match(parsed.body, /## Abstract/);
+});
+
+test('front matter parser supports template comments without stripping URL fragments', () => {
+  const source = makeHip()
+    .replace('hip: 123', 'hip: 123 # Assigned by an editor')
+    .replace('Example Author (@example)', "Pat O'Brien (@example) # Primary author")
+    .replace('/pull/123', '/pull/123#discussion_r1');
+  const parsed = parseFrontMatter(source);
+  assert.equal(parsed.fields.hip, '123');
+  assert.equal(parsed.fields.author, "Pat O'Brien (@example)");
+  assert.equal(
+    parsed.fields['discussions-to'],
+    'https://github.com/hiero-ledger/hiero-improvement-proposals/pull/123#discussion_r1',
+  );
+});
+
+test('front matter parser treats quoted YAML scalars as their values', () => {
+  const source = makeHip()
+    .replace('type: Standards Track', 'type: "Standards Track"')
+    .replace('category: Service', "category: 'Service'")
+    .replace('status: Draft', 'status: "Draft"');
+  assertValidDocument(source);
+});
+
+test('front matter parser reports malformed delimiters, lines, and duplicate headers', async (t) => {
+  await t.test('opening delimiter', () => {
+    assert.deepEqual(codes(parseFrontMatter('hip: 123\n---\n')), ['frontmatter-opening-delimiter']);
+  });
+  await t.test('closing delimiter', () => {
+    assert.deepEqual(codes(parseFrontMatter('---\nhip: 123\n')), ['frontmatter-closing-delimiter']);
+  });
+  await t.test('malformed line and duplicate', () => {
+    const parsed = parseFrontMatter('---\nhip: 123\nnot a header\nhip: 456\n---\n');
+    assert.deepEqual(codes(parsed), ['frontmatter-line-format', 'duplicate-header']);
+  });
+});
+
+test('new Draft HIPs pass for every HIP-1 type and category flow', async (t) => {
+  const variants = [
+    ['Standards Track / Core', { type: 'Standards Track', category: 'Core' }],
+    ['Standards Track / Service', { type: 'Standards Track', category: 'Service' }],
+    ['Standards Track / Mirror', { type: 'Standards Track', category: 'Mirror' }],
+    ['Standards Track / Block Node', { type: 'Standards Track', category: 'Block Node' }],
+    ['Standards Track / Application', {
+      type: 'Standards Track',
+      category: 'Application',
+      needsHieroApproval: 'No',
+      needsHederaReview: 'No',
+    }],
+    ['Informational', {
+      type: 'Informational',
+      category: null,
+      needsHieroApproval: 'No',
+      needsHederaReview: 'No',
+    }],
+    ['Process', {
+      type: 'Process',
+      category: null,
+      needsHieroApproval: 'No',
+      needsHederaReview: 'No',
+    }],
+  ];
+
+  for (const [name, variant] of variants) {
+    await t.test(name, () => {
+      const source = makeHip({ hip: '0000', ...variant });
+      const validation = validateChange(source, {
+        path: 'HIP/hip-0000-example.md',
+        baseSource: null,
+        today: '2026-08-01',
+      });
+      assert.deepEqual(validation.errors, []);
+      assert.equal(validation.isNew, true);
+    });
+  }
+});
+
+test('new HIPs must use Draft status and the HIP-1 placeholder number and filename', () => {
+  const notDraft = validateChange(makeHip({ hip: '0000', status: 'Review' }), {
+    path: 'HIP/hip-0000-example.md',
+    baseSource: null,
+  });
+  assert.ok(codes(notDraft, 'errors').includes('new-hip-status'));
+
+  const wrongFilename = validateChange(makeHip({ hip: '0000' }), {
+    path: 'HIP/my-proposal.md',
+    baseSource: null,
+  });
+  assert.ok(codes(wrongFilename, 'errors').includes('hip-filename'));
+
+  const wrongNumber = validateChange(makeHip(), {
+    path: 'HIP/hip-456.md',
+    baseSource: null,
+  });
+  assert.ok(codes(wrongNumber, 'errors').includes('hip-filename-number'));
+});
+
+test('every current status is accepted only by its HIP-1 workflow', async (t) => {
+  const standardStatuses = [
+    'Draft', 'Review', 'Last Call', 'Approved', 'Final',
+    'Deferred', 'Withdrawn', 'Stagnant', 'Rejected', 'Replaced',
+  ];
+  const activeStatuses = [
+    'Draft', 'Review', 'Last Call', 'Active',
+    'Deferred', 'Withdrawn', 'Stagnant', 'Rejected', 'Replaced',
+  ];
+
+  await t.test('Standards Track approval flow statuses', () => {
+    for (const status of standardStatuses) {
+      assertValidDocument(makeHip({ status }));
+    }
+  });
+
+  for (const [name, variant] of [
+    ['Application', { type: 'Standards Track', category: 'Application' }],
+    ['Informational', { type: 'Informational', category: null }],
+    ['Process', { type: 'Process', category: null }],
+  ]) {
+    await t.test(`${name} active flow statuses`, () => {
+      for (const status of activeStatuses) {
+        assertValidDocument(makeHip({
+          ...variant,
+          needsHieroApproval: 'No',
+          needsHederaReview: 'No',
+          status,
+        }));
+      }
+    });
+  }
+
+  const standardActive = validateDocument(makeHip({ status: 'Active' }), { path: 'HIP/hip-123.md' });
+  assert.ok(codes(standardActive).includes('status-for-flow'));
+
+  for (const status of ['Approved', 'Final']) {
+    const applicationResolution = validateDocument(makeHip({
+      category: 'Application',
+      needsHieroApproval: 'No',
+      needsHederaReview: 'No',
+      status,
+    }), { path: 'HIP/hip-123.md' });
+    assert.ok(codes(applicationResolution).includes('status-for-flow'));
+  }
+});
+
+test('approval and review flags follow each HIP-1 workflow', async (t) => {
+  await t.test('approval-track categories require Yes', () => {
+    for (const category of ['Core', 'Service', 'Mirror', 'Block Node']) {
+      for (const field of ['needsHieroApproval', 'needsHederaReview']) {
+        const invalid = validateDocument(makeHip({ category, [field]: 'No' }), {
+          path: 'HIP/hip-123.md',
+        });
+        assert.ok(codes(invalid).includes('approval-for-flow'), `${category} ${field}`);
+      }
+    }
+  });
+
+  await t.test('active-flow types require No', () => {
+    const variants = [
+      { type: 'Standards Track', category: 'Application' },
+      { type: 'Informational', category: null },
+      { type: 'Process', category: null },
+    ];
+    for (const variant of variants) {
+      const invalid = validateDocument(makeHip({ ...variant }), { path: 'HIP/hip-123.md' });
+      assert.equal(codes(invalid).filter((code) => code === 'approval-for-flow').length, 2);
+    }
+  });
+});
+
+test('type, category, and status spellings are exact', () => {
+  const invalid = validateDocument(makeHip({
+    type: 'Standards',
+    category: 'API',
+    status: 'Council Review',
+  }), { path: 'HIP/hip-123.md' });
+  assert.ok(codes(invalid).includes('type-value'));
+  assert.ok(codes(invalid).includes('status-value'));
+
+  const invalidCategory = validateDocument(makeHip({ category: 'Mirror Node' }), {
+    path: 'HIP/hip-123.md',
+  });
+  assert.ok(codes(invalidCategory).includes('category-value'));
+});
+
+test('discussions-to must be a full HTTP(S) URL', () => {
+  const invalid = validateDocument(makeHip({ discussionsTo: 'PR 123' }), {
+    path: 'HIP/hip-123.md',
+  });
+  assert.ok(codes(invalid).includes('discussions-url'));
+});
+
+test('Accepted is grandfathered only for pre-2025 Standards Track HIPs', () => {
+  assertValidDocument(makeHip({
+    status: 'Accepted',
+    created: '2024-12-31',
+    updated: '2024-12-31',
+  }));
+
+  const modern = validateDocument(makeHip({ status: 'Accepted' }), { path: 'HIP/hip-123.md' });
+  assert.ok(codes(modern).includes('legacy-accepted-status'));
+});
+
+test('status-specific headers are enforced', () => {
+  const lastCall = validateDocument(makeHip({
+    status: 'Last Call',
+    lastCallDateTime: '',
+  }), { path: 'HIP/hip-123.md' });
+  assert.ok(codes(lastCall).includes('last-call-date-time-required'));
+
+  const final = validateDocument(makeHip({ status: 'Final', release: '' }), {
+    path: 'HIP/hip-123.md',
+  });
+  assert.ok(codes(final).includes('release-required'));
+
+  const replaced = validateDocument(makeHip({ status: 'Replaced', supersededBy: '' }), {
+    path: 'HIP/hip-123.md',
+  });
+  assert.ok(codes(replaced).includes('superseded-by-required'));
+});
+
+test('dates, timestamps, and HIP reference lists are validated', () => {
+  const invalid = validateDocument(makeHip({
+    created: '2026-02-30',
+    updated: '2026-09-01, 2026-08-01',
+    lastCallDateTime: '2026-09-15 07:00:00 UTC',
+    requires: '123, cutover',
+  }), { path: 'HIP/hip-123.md' });
+  const invalidCodes = codes(invalid);
+  assert.ok(invalidCodes.includes('date-format'));
+  assert.ok(invalidCodes.includes('updated-date-order'));
+  assert.ok(invalidCodes.includes('last-call-date-time-format'));
+  assert.ok(invalidCodes.includes('hip-reference-list'));
+});
+
+test('Hedera decision metadata is paired and follows approval ordering', () => {
+  assertValidDocument(makeHip({
+    status: 'Approved',
+    hederaDecision: 'Accepted',
+    hederaReviewedOn: '2026-08-20',
+  }));
+
+  const incomplete = validateDocument(makeHip({
+    status: 'Approved',
+    hederaDecision: 'Accepted',
+  }), { path: 'HIP/hip-123.md' });
+  assert.ok(codes(incomplete).includes('hedera-review-pair'));
+
+  const tooEarly = validateDocument(makeHip({
+    status: 'Review',
+    hederaDecision: 'Accepted',
+    hederaReviewedOn: '2026-08-20',
+  }), { path: 'HIP/hip-123.md' });
+  assert.ok(codes(tooEarly).includes('hedera-review-before-approved'));
+});
+
+test('all primary transitions pass across all HIP types and categories', async (t) => {
+  const transitions = [
+    ['Core Draft → Review', { category: 'Core' }, 'Draft', 'Review'],
+    ['Service Review → Last Call', { category: 'Service' }, 'Review', 'Last Call'],
+    ['Mirror Last Call → Approved', { category: 'Mirror' }, 'Last Call', 'Approved'],
+    ['Block Node Approved → Final', { category: 'Block Node' }, 'Approved', 'Final'],
+    ['Application Last Call → Active', {
+      category: 'Application', needsHieroApproval: 'No', needsHederaReview: 'No',
+    }, 'Last Call', 'Active'],
+    ['Informational Review → Last Call', {
+      type: 'Informational', category: null, needsHieroApproval: 'No', needsHederaReview: 'No',
+    }, 'Review', 'Last Call'],
+    ['Process Last Call → Active', {
+      type: 'Process', category: null, needsHieroApproval: 'No', needsHederaReview: 'No',
+    }, 'Last Call', 'Active'],
+  ];
+
+  for (const [name, variant, from, to] of transitions) {
+    await t.test(name, () => {
+      const baseSource = makeHip({ ...variant, status: from });
+      const source = makeHip({ ...variant, status: to, updated: '2026-09-01' });
+      const validation = validateChange(source, {
+        path: 'HIP/hip-123.md',
+        baseSource,
+        today: '2026-09-01',
+      });
+      assert.deepEqual(validation.errors, []);
+    });
+  }
+});
+
+test('Last Call may be waived for a minor change as documented by HIP-1', () => {
+  const standard = validateChange(makeHip({ status: 'Approved', updated: '2026-09-01' }), {
+    path: 'HIP/hip-123.md',
+    baseSource: makeHip({ status: 'Review' }),
+    today: '2026-09-01',
+  });
+  assert.deepEqual(standard.errors, []);
+
+  const activeVariant = {
+    type: 'Process',
+    category: null,
+    needsHieroApproval: 'No',
+    needsHederaReview: 'No',
+  };
+  const active = validateChange(makeHip({
+    ...activeVariant,
+    status: 'Active',
+    updated: '2026-09-01',
+  }), {
+    path: 'HIP/hip-123.md',
+    baseSource: makeHip({ ...activeVariant, status: 'Review' }),
+    today: '2026-09-01',
+  });
+  assert.deepEqual(active.errors, []);
+});
+
+test('the complete status-transition matrix matches both HIP-1 workflows', async (t) => {
+  const workflows = [
+    ['Standards Track', {}, {
+      Draft: ['Draft', 'Review', 'Deferred', 'Withdrawn', 'Stagnant'],
+      Review: ['Review', 'Last Call', 'Approved', 'Rejected', 'Stagnant'],
+      'Last Call': ['Last Call', 'Approved', 'Rejected', 'Withdrawn', 'Stagnant'],
+      Approved: ['Approved', 'Final'],
+      Final: ['Final', 'Replaced'],
+      Deferred: ['Deferred', 'Draft'],
+      Stagnant: ['Stagnant', 'Draft'],
+      Withdrawn: ['Withdrawn'],
+      Rejected: ['Rejected'],
+      Replaced: ['Replaced'],
+    }],
+    ['Informational / Process / Application', {
+      type: 'Process',
+      category: null,
+      needsHieroApproval: 'No',
+      needsHederaReview: 'No',
+    }, {
+      Draft: ['Draft', 'Review', 'Deferred', 'Withdrawn', 'Stagnant'],
+      Review: ['Review', 'Last Call', 'Active', 'Rejected', 'Stagnant'],
+      'Last Call': ['Last Call', 'Active', 'Rejected', 'Withdrawn', 'Stagnant'],
+      Active: ['Active', 'Replaced'],
+      Deferred: ['Deferred', 'Draft'],
+      Stagnant: ['Stagnant', 'Draft'],
+      Withdrawn: ['Withdrawn'],
+      Rejected: ['Rejected'],
+      Replaced: ['Replaced'],
+    }],
+  ];
+
+  for (const [name, variant, expected] of workflows) {
+    await t.test(name, () => {
+      const statuses = Object.keys(expected);
+      for (const from of statuses) {
+        for (const to of statuses) {
+          const validation = validateChange(makeHip({
+            ...variant,
+            status: to,
+            updated: '2026-09-01',
+          }), {
+            path: 'HIP/hip-123.md',
+            baseSource: makeHip({ ...variant, status: from }),
+            today: '2026-09-01',
+          });
+          const transitionFailed = codes(validation, 'errors').includes('status-transition');
+          assert.equal(
+            transitionFailed,
+            !expected[from].includes(to),
+            `${name}: ${from} → ${to}`,
+          );
+        }
+      }
+    });
+  }
+});
+
+test('terminal, skipped, and cross-flow transitions fail helpfully', () => {
+  const skipped = validateChange(makeHip({ status: 'Final', updated: '2026-09-01' }), {
+    path: 'HIP/hip-123.md',
+    baseSource: makeHip({ status: 'Draft' }),
+    today: '2026-09-01',
+  });
+  assert.ok(codes(skipped, 'errors').includes('status-transition'));
+  assert.match(
+    skipped.errors.find((entry) => entry.code === 'status-transition').suggestion,
+    /Review, Deferred, Withdrawn, Stagnant/,
+  );
+
+  const terminal = validateChange(makeHip({ status: 'Review', updated: '2026-09-01' }), {
+    path: 'HIP/hip-123.md',
+    baseSource: makeHip({ status: 'Rejected' }),
+    today: '2026-09-01',
+  });
+  assert.ok(codes(terminal, 'errors').includes('status-transition'));
+
+  const wrongResolution = validateChange(makeHip({
+    category: 'Application',
+    needsHieroApproval: 'No',
+    needsHederaReview: 'No',
+    status: 'Approved',
+    updated: '2026-09-01',
+  }), {
+    path: 'HIP/hip-123.md',
+    baseSource: makeHip({
+      category: 'Application',
+      needsHieroApproval: 'No',
+      needsHederaReview: 'No',
+      status: 'Last Call',
+    }),
+    today: '2026-09-01',
+  });
+  assert.ok(codes(wrongResolution, 'errors').includes('status-for-flow'));
+  assert.ok(codes(wrongResolution, 'errors').includes('status-transition'));
+});
+
+test('existing HIP edits require a non-regressing updated date', () => {
+  const baseSource = makeHip();
+  const unchangedDate = validateChange(`${makeHip()}\nChanged body.\n`, {
+    path: 'HIP/hip-123.md',
+    baseSource,
+    today: '2026-09-01',
+  });
+  assert.ok(codes(unchangedDate, 'errors').includes('updated-date-not-recorded'));
+
+  const updated = validateChange(makeHip({ updated: '2026-09-01', body: 'Changed body.' }), {
+    path: 'HIP/hip-123.md',
+    baseSource,
+    today: '2026-09-01',
+  });
+  assert.deepEqual(updated.errors, []);
+
+  const regressed = validateChange(makeHip({ updated: '2026-07-01', body: 'Changed body.' }), {
+    path: 'HIP/hip-123.md',
+    baseSource,
+    today: '2026-09-01',
+  });
+  assert.ok(codes(regressed, 'errors').includes('updated-date-regressed'));
+});
+
+test('HIP number and creation date cannot change after assignment', () => {
+  const baseSource = makeHip();
+  const changed = validateChange(makeHip({
+    hip: '456',
+    created: '2026-08-02',
+    updated: '2026-09-01',
+  }), {
+    path: 'HIP/hip-456.md',
+    baseSource,
+    today: '2026-09-01',
+  });
+  const errorCodes = codes(changed, 'errors');
+  assert.ok(errorCodes.includes('hip-number-changed'));
+  assert.ok(errorCodes.includes('created-date-changed'));
+});
+
+test('pre-existing legacy issues warn without blocking unrelated edits', () => {
+  const variant = { requestedBy: null, type: 'Standards', category: 'Core' };
+  const validation = validateChange(makeHip({ ...variant, updated: '2026-09-01' }), {
+    path: 'HIP/hip-123.md',
+    baseSource: makeHip(variant),
+    today: '2026-09-01',
+  });
+  assert.deepEqual(validation.errors, []);
+  assert.ok(codes(validation, 'warnings').includes('required-header'));
+  assert.ok(codes(validation, 'warnings').includes('type-value'));
+});
+
+test('newly introduced violations still fail an existing legacy HIP', () => {
+  const baseSource = makeHip({ requestedBy: null });
+  const validation = validateChange(makeHip({
+    requestedBy: null,
+    title: '<The HIP Title>',
+    updated: '2026-09-01',
+  }), {
+    path: 'HIP/hip-123.md',
+    baseSource,
+    today: '2026-09-01',
+  });
+  assert.ok(codes(validation, 'warnings').includes('required-header'));
+  assert.ok(codes(validation, 'errors').includes('placeholder-header'));
+});
+
+test('every merged HIP can be edited without pre-existing metadata blocking the PR', () => {
+  const hipDirectory = path.join(REPOSITORY_ROOT, 'HIP');
+  const hipFiles = fs.readdirSync(hipDirectory)
+    .filter((filename) => /^hip-\d+\.md$/.test(filename));
+  assert.ok(hipFiles.length > 100, 'expected the merged HIP corpus');
+
+  for (const filename of hipFiles) {
+    const source = fs.readFileSync(path.join(hipDirectory, filename), 'utf8');
+    const validation = validateChange(source, {
+      path: `HIP/${filename}`,
+      baseSource: source,
+      today: '2026-09-01',
+    });
+    assert.deepEqual(validation.errors, [], filename);
+  }
+});
+
+test('CLI aggregates actionable errors and emits GitHub annotations', (t) => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hip-validator-'));
+  t.after(() => fs.rmSync(temporaryDirectory, { recursive: true, force: true }));
+  const hipDirectory = path.join(temporaryDirectory, 'HIP');
+  fs.mkdirSync(hipDirectory);
+  const hipPath = path.join(hipDirectory, 'hip-0000-example.md');
+  fs.writeFileSync(hipPath, makeHip({
+    hip: '0000',
+    type: 'Informational',
+    category: null,
+    needsHieroApproval: 'Yes',
+    needsHederaReview: 'Yes',
+  }));
+
+  const result = spawnSync(process.execPath, [path.join(__dirname, 'validateHIP.js'), hipPath], {
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_ACTIONS: 'true' },
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /conflicts with the HIP-1/);
+  assert.match(result.stdout, /::error file=HIP\/hip-0000-example\.md/);
+  assert.match(result.stdout, /Fix:/);
+});
+
+test('CLI compares a renamed HIP with its original base path', (t) => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hip-validator-git-'));
+  t.after(() => fs.rmSync(temporaryDirectory, { recursive: true, force: true }));
+  const hipDirectory = path.join(temporaryDirectory, 'HIP');
+  fs.mkdirSync(hipDirectory);
+  const originalPath = path.join(hipDirectory, 'hip-123.md');
+  const renamedPath = path.join(hipDirectory, 'hip-123-renamed.md');
+  fs.writeFileSync(originalPath, makeHip({ status: 'Draft' }));
+
+  for (const args of [
+    ['init', '-q'],
+    ['config', 'user.name', 'Validator Test'],
+    ['config', 'user.email', 'validator@example.com'],
+    ['config', 'commit.gpgsign', 'false'],
+    ['add', 'HIP/hip-123.md'],
+    ['commit', '-qm', 'base'],
+  ]) {
+    const git = spawnSync('git', args, { cwd: temporaryDirectory, encoding: 'utf8' });
+    assert.equal(git.status, 0, git.stderr);
+  }
+  const base = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: temporaryDirectory,
+    encoding: 'utf8',
+  }).stdout.trim();
+  fs.renameSync(originalPath, renamedPath);
+  fs.writeFileSync(renamedPath, makeHip({ status: 'Review', updated: '2026-09-01' }));
+  for (const args of [
+    ['add', '-A'],
+    ['commit', '-qm', 'rename HIP'],
+  ]) {
+    const git = spawnSync('git', args, { cwd: temporaryDirectory, encoding: 'utf8' });
+    assert.equal(git.status, 0, git.stderr);
+  }
+
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'validateHIP.js'), '--base-ref', base, 'HIP/hip-123-renamed.md'],
+    { cwd: temporaryDirectory, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /follows HIP-1/);
+});
+
+test('workflow validates git-discovered HIP files without API secrets or pagination', () => {
+  const workflow = fs.readFileSync(
+    path.join(REPOSITORY_ROOT, '.github/workflows/validateHeaders.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /git diff --name-only --diff-filter=ACMR -z/);
+  assert.match(workflow, /--base-ref "\$BASE_SHA"/);
+  assert.match(workflow, /node-version: "20"/);
+  assert.match(workflow, /run: npm test/);
+  assert.doesNotMatch(workflow, /VERTESIA|curl|jq|GITHUB_TOKEN/);
+});


### PR DESCRIPTION
## Summary

- Replace the unavailable Vertesia-based validator with deterministic, dependency-free HIP-1 validation.
- Enforce the distinct Standards Track and Informational/Process/Application status flows, valid transitions, approval flags, dates, references, and status-specific metadata.
- Compare changed HIPs with the PR base so pre-existing legacy metadata is reported without blocking unrelated edits, while newly introduced problems still fail.
- Discover every changed HIP with git instead of the paginated pull-files API, and emit actionable GitHub annotations plus a job summary.
- Run the validator test suite in the action under Node 20.

## Validation

- Root npm test: 51 passing tests, including every HIP type/category, both complete status-transition matrices, CLI behavior, rename handling, and all 158 merged HIPs.
- Site npm test: 7 passing tests.
- Site npm run build: production build succeeds.
- actionlint passes (with the repository custom runner label ignored).
- git diff --check passes.
- Commit includes a matching Signed-off-by trailer and a GPG signature.