### PR TITLE
chore: mark HIP-1342 as Approved

### DIFF
--- a/HIP/hip-1342.md
+++ b/HIP/hip-1342.md
@@ -9,10 +9,10 @@ type: Standards Track
 category: Service
 needs-hiero-approval: Yes
 needs-hedera-review: Yes
-status: Last Call
+status: Approved
 last-call-date-time: 2026-05-20T07:00:00Z
 created: 2025-11-14
-updated: 2026-05-06
+updated: 2026-09-02
 release:
 ---
 


### PR DESCRIPTION
HIP-1342 (Ignore Trailing Calldata for System Contracts) was approved by the Hiero TSC on 2026-08-18 (see hiero-ledger/tsc#297 and the HIPs tracker board). The HIP file on `main` still says `Last Call`, so hips.hedera.com lists it under Last Call.

This updates `status` to `Approved` and bumps `updated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)